### PR TITLE
Qol 5530 cloudfront corrects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ If you would like to become the maintainer of this repository, please contact in
 * AWS RDS for Postgres
 
 See the [wiki](https://github.com/DataShades/opswx-ckan-cookbook/wiki) for detailed documentation
+
+
+Commands after cookbook update:
+* update_custom_cookbooks (all)
+* deploy (per app)
+* configure (per app)
+
+or (if outage is ok)
+* update_custom_cookbooks 
+* setup
+

--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -34,6 +34,7 @@ default['datashades']['ckan_web']['adminemail'] = 'admin@nowhere.com'
 default['datashades']['ckan_web']['feedback_recipients'] = 'opendata@qld.gov.au'
 default['datashades']['ckan_web']['feedback_redirection'] = '/article/thanks'
 default['datashades']['ckan_web']['title'] = 'CKAN'
+default['datashades']['ckan_web']['email_domain'] = node['datashades']['public_tld']
 
 default['datashades']['ckan_web']['sentryurl'] = ''
 

--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -34,7 +34,6 @@ default['datashades']['ckan_web']['adminemail'] = 'admin@nowhere.com'
 default['datashades']['ckan_web']['feedback_recipients'] = 'opendata@qld.gov.au'
 default['datashades']['ckan_web']['feedback_redirection'] = '/article/thanks'
 default['datashades']['ckan_web']['title'] = 'CKAN'
-default['datashades']['ckan_web']['email_domain'] = node['datashades']['public_tld']
 
 default['datashades']['ckan_web']['sentryurl'] = ''
 

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -262,7 +262,7 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 					ln -sf bootstrap-$CUSTOM_BOOTSTRAP_VERSION.min.js bootstrap.min.js
 				fi
 			EOS
-			only_if { "#{pluginname}".eql? 'data_qld_theme' }
+			only_if { "#{pluginname}".eql? 'data-qld-theme' }
 		end
 
 		# Viewhelpers is a special case because stats needs to be loaded before it

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -110,7 +110,8 @@ template "#{config_file}" do
 	mode "0755"
 	variables({
 		:app_name =>  app['shortname'],
-		:app_url => app['domains'][0]
+		:app_url => app['domains'][0],
+		:email_domain => node['datashades']['ckan_web']['email_domain']
 	})
 	action :create
 end
@@ -225,8 +226,7 @@ template '/etc/httpd/conf.d/ckan.conf' do
 	variables({
 		:app_name =>  app['shortname'],
 		:app_url => app['domains'][0],
-		:domains => app['domains'],
-		:email_domain => node['datashades']['ckan_web']['email_domain']
+		:domains => app['domains']
 	})
 	action :create
 end

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -226,7 +226,7 @@ template '/etc/httpd/conf.d/ckan.conf' do
 		:app_name =>  app['shortname'],
 		:app_url => app['domains'][0],
 		:domains => app['domains'],
-		:email_domain => node['datashades']['email_domain']
+		:email_domain => node['datashades']['ckan_web']['email_domain']
 	})
 	action :create
 end

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -115,30 +115,31 @@ template "#{config_file}" do
 	action :create
 end
 
-# Update the CKAN site_url with the best public domain name we can find.
-# Best is a public DNS alias pointing to CloudFront.
-# Next best is the CloudFront distribution domain.
-# Use the load balancer address if there's no CloudFront.
-#
-app_url = app['domains'][0]
-bash "Detect public domain name" do
-	user "#{service_name}"
-	code <<-EOS
-		cloudfront_domain=$(aws cloudfront list-distributions --query "DistributionList.Items[].{DomainName: DomainName, OriginDomainName: Origins.Items[].DomainName}[?contains(OriginDomainName, '#{app_url}')] | [0].DomainName" --output json | tr -d '"')
-		if [ "$cloudfront_domain" != "null" ]; then
-			public_name="$cloudfront_domain"
-			zoneid=$(aws route53 list-hosted-zones-by-name --dns-name "#{node['datashades']['public_tld']}" | jq '.HostedZones[0].Id' | tr -d '"/hostedzone')
-			record_name=$(aws route53 list-resource-record-sets --hosted-zone-id $zoneid --query "ResourceRecordSets[?AliasTarget].{Name: Name, Target: AliasTarget.DNSName}[?contains(Target, '$cloudfront_domain')] | [0].Name" --output json |tr -d '"' |sed 's/[.]$//')
-			if [ "$record_name" != "null" ]; then
-				public_name="$record_name"
-				sed -i "s|^smtp[.]mail_from\s*=\([^@]*\)@.*$|smtp.mail_from=\1@$public_name|" #{config_file}
-			fi
-		fi
-		if [ ! -z "$public_name" ]; then
-			sed -i "s|^ckan[.]site_url\s*=.*$|ckan.site_url=https://$public_name/|" #{config_file}
-		fi
-	EOS
-end
+# app_url == Domains[0] is used for site_url, email domain defaults to public_tld if email_domain is not injected via attributes/ckan.rb
+# # Update the CKAN site_url with the best public domain name we can find.
+# # Best is a public DNS alias pointing to CloudFront.
+# # Next best is the CloudFront distribution domain.
+# # Use the load balancer address if there's no CloudFront.
+# #
+# app_url = app['domains'][0]
+# bash "Detect public domain name" do
+# 	user "#{service_name}"
+# 	code <<-EOS
+# 		cloudfront_domain=$(aws cloudfront list-distributions --query "DistributionList.Items[].{DomainName: DomainName, OriginDomainName: Origins.Items[].DomainName}[?contains(OriginDomainName, '#{app_url}')] | [0].DomainName" --output json | tr -d '"')
+# 		if [ "$cloudfront_domain" != "null" ]; then
+# 			public_name="$cloudfront_domain"
+# 			zoneid=$(aws route53 list-hosted-zones-by-name --dns-name "#{node['datashades']['public_tld']}" | jq '.HostedZones[0].Id' | tr -d '"/hostedzone')
+# 			record_name=$(aws route53 list-resource-record-sets --hosted-zone-id $zoneid --query "ResourceRecordSets[?AliasTarget].{Name: Name, Target: AliasTarget.DNSName}[?contains(Target, '$cloudfront_domain')] | [0].Name" --output json |tr -d '"' |sed 's/[.]$//')
+# 			if [ "$record_name" != "null" ]; then
+# 				public_name="$record_name"
+# 				sed -i "s|^smtp[.]mail_from\s*=\([^@]*\)@.*$|smtp.mail_from=\1@$public_name|" #{config_file}
+# 			fi
+# 		fi
+# 		if [ ! -z "$public_name" ]; then
+# 			sed -i "s|^ckan[.]site_url\s*=.*$|ckan.site_url=https://$public_name/|" #{config_file}
+# 		fi
+# 	EOS
+# end
 
 node.default['datashades']['auditd']['rules'].push("#{config_file}")
 
@@ -223,7 +224,9 @@ template '/etc/httpd/conf.d/ckan.conf' do
 	mode '0755'
 	variables({
 		:app_name =>  app['shortname'],
-		:app_url => app['domains'][0]
+		:app_url => app['domains'][0],
+		:domains => app['domains'],
+		:email_domain => node['datashades']['email_domain']
 	})
 	action :create
 end

--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -1,12 +1,6 @@
 <VirtualHost 127.0.0.1:8000>
     ServerName <%= @app_url %>
     ServerAlias www.<%= @app_url %>
-
-    # Use canonical domain
-    RewriteEngine on
-    RewriteCond %{HTTP:X-Forwarded-Host} www\.([-_.a-z]*\.qld\.gov\.au)
-    RewriteRule ^/(.*)$ https://%1/$1 [R=301,L]
-
     WSGIScriptAlias <%= node['datashades']['ckan_web']['endpoint'] %> /etc/ckan/default/apache.wsgi
 
     # Pass authorization info on (needed for rest api).

--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -1,6 +1,9 @@
 <VirtualHost 127.0.0.1:8000>
     ServerName <%= @app_url %>
     ServerAlias www.<%= @app_url %>
+    <% @domains.each do |domain| %>
+    ServerAlias <%= domain%>
+    <% end %>
     WSGIScriptAlias <%= node['datashades']['ckan_web']['endpoint'] %> /etc/ckan/default/apache.wsgi
 
     # Pass authorization info on (needed for rest api).

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -152,7 +152,7 @@ ckan.datarequests.default_organisation = open-data-administration-data-requests
 ckan.odi_certificates.certificate_base_url = https://certificates.theodi.org/en/datasets?
 ckan.odi_certificates.certificate_img_query_parameters = {"datasetUrl":"", "format":"png", "type":"badge"}
 ckan.odi_certificates.certificate_link_query_parameters = {"datasetUrl":""}
-ckan.odi_certificates.dataset_base_url = https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>
+ckan.odi_certificates.dataset_base_url = https://<%= node['datashades']['public_tld'] %>
 
 scheming.dataset_schemas = ckanext.data_qld:ckan_dataset.json
 scheming.presets = ckanext.scheming:presets.json ckanext.data_qld:presets.json

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -152,7 +152,7 @@ ckan.datarequests.default_organisation = open-data-administration-data-requests
 ckan.odi_certificates.certificate_base_url = https://certificates.theodi.org/en/datasets?
 ckan.odi_certificates.certificate_img_query_parameters = {"datasetUrl":"", "format":"png", "type":"badge"}
 ckan.odi_certificates.certificate_link_query_parameters = {"datasetUrl":""}
-ckan.odi_certificates.dataset_base_url = https://<%= node['datashades']['public_tld'] %>
+ckan.odi_certificates.dataset_base_url = https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>
 
 scheming.dataset_schemas = ckanext.data_qld:ckan_dataset.json
 scheming.presets = ckanext.scheming:presets.json ckanext.data_qld:presets.json
@@ -224,15 +224,15 @@ ckan.email_notifications_since = 2 days
 #email_to = admin@<%= node['datashades']['tld'] %>
 #error_email_from = ckan@<%= @app_url %>
 <% else -%>
-#email_to = admin@<%= node['datashades']['public_tld'] %>
-error_email_from = no-reply@<%= node['datashades']['public_tld'] %>
+#email_to = admin@<%= @email_domain %>
+error_email_from = no-reply@<%= @email_domain %>
 <% end -%>
 
 smtp.server = 127.0.1.1
 smtp.starttls = False
 #smtp.user = your_username@gmail.com
 #smtp.password = your_password
-smtp.mail_from = no-reply@<%= node['datashades']['public_tld'] %>
+smtp.mail_from = no-reply@<%= @email_domain %>
 
 # CORS Settings
 ckan.cors.origin_allow_all = True


### PR DESCRIPTION
use first domain in cloudformation opsworks list for site url, use rest as alias's, add extra email domain but default to public_tld if not set 