### PR TITLE
[QOL-5759] enable reload action on Apache service

### DIFF
--- a/recipes/httpd-configure.rb
+++ b/recipes/httpd-configure.rb
@@ -37,5 +37,6 @@ file "/etc/cron.daily/archive-apache-logs-to-s3" do
 end
 
 service 'httpd' do
+	supports :restart => true, :reload => true, :status => true
 	action [:reload]
 end


### PR DESCRIPTION
- without this, OpsWorks doesn't actually issue the reload command