### PR TITLE
[QOL-4841] add health monitoring for Solr servers

### DIFF
--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -31,11 +31,26 @@ template "/usr/local/sbin/archive-solr-logs.sh" do
 	mode "0755"
 end
 
+template "/usr/local/bin/solr-healthcheck.sh" do
+	source "solr-healthcheck.sh.erb"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
 file "/etc/cron.daily/archive-solr-logs-to-s3" do
 	content "/usr/local/sbin/archive-solr-logs.sh 2>&1 >/dev/null\n"
 	owner "root"
 	group "root"
 	mode "0755"
+end
+
+file "/data/solr-healthcheck_#{node['datashades']['hostname']}" do
+	action :touch
+end
+
+cron "Solr health check" do
+	command "/usr/local/bin/solr-healthcheck.sh > /dev/null"
 end
 
 # Add DNS entry for service host

--- a/recipes/solr-shutdown.rb
+++ b/recipes/solr-shutdown.rb
@@ -22,6 +22,10 @@
 
 service_name = 'solr'
 
+file "/data/solr-healthcheck_#{node['datashades']['hostname']}" do
+	action :delete
+end
+
 # Remove DNS records to stop requests to this host
 #
 bash "Delete #{service_name} DNS record" do

--- a/templates/default/solr-healthcheck.sh.erb
+++ b/templates/default/solr-healthcheck.sh.erb
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+HEARTBEAT_FILE="/data/solr-healthcheck_<%= node['datashades']['hostname'] %>"
+if [ -e "$HEARTBEAT_FILE" ]; then
+  CURRENT_TIME=`date +%s`
+  if (curl -I "http://localhost:8983/solr/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/admin/ping" 2>/dev/null |grep '200 OK' > /dev/null); then
+    echo $CURRENT_TIME > "$HEARTBEAT_FILE"
+  else
+    exit 1
+  fi
+fi


### PR DESCRIPTION
- Each server creates a health check file on the EFS, named after itself and containing a timestamp of when it was last verified healthy (seconds since epoch).
This file is created on 'configure', updated via cron every minute unless manually deleted, and removed on shutdown.
Not yet used for anything, but will eventually serve as a method of coordinating master + slaves.