### PR TITLE
Qol 5833 move logs off efs

### DIFF
--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -24,15 +24,8 @@ include_recipe "datashades::default-configure"
 
 service_name = 'solr'
 
-template "/usr/local/bin/archive-solr-logs.sh" do
-	source "archive-solr-logs.sh.erb"
-	owner "root"
-	group "root"
-	mode "0755"
-end
-
 file "/etc/cron.daily/archive-solr-logs-to-s3" do
-	content "/usr/local/bin/archive-solr-logs.sh 2>&1 >/dev/null\n"
+	content "/usr/local/bin/archive-logs.sh #{service_name} 2>&1 >/dev/null\n"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -86,6 +86,18 @@ unless (::File.directory?("/data/solr"))
 	end
 end
 
+efs_log_dir = "/data/solr/logs"
+ebs_log_dir = "/var/log/solr"
+
+bash "Move logs to EBS" do
+	user "root"
+	code <<-EOS
+		mv #{efs_log_dir} #{ebs_log_dir}
+		ln -s #{ebs_log_dir} #{efs_log_dir}
+	EOS
+	not_if { ::File.symlink?("#{efs_log_dir}") }
+end
+
 # Create Monit config file to restart Solr when port 8983 not available
 # Solves instance start issue after Solr install when /data doesn't mount fast enough
 #

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -98,6 +98,15 @@ bash "Move logs to EBS" do
 	not_if { ::File.symlink?("#{efs_log_dir}") }
 end
 
+# Just in case the symlink was broken eg when creating a new instance with existing EFS data
+directory "#{ebs_log_dir}" do
+  owner "solr"
+  group "ec2-user"
+  mode "0775"
+  recursive true
+  action :create
+end
+
 # Create Monit config file to restart Solr when port 8983 not available
 # Solves instance start issue after Solr install when /data doesn't mount fast enough
 #

--- a/recipes/solr-shutdown.rb
+++ b/recipes/solr-shutdown.rb
@@ -34,8 +34,15 @@ bash "Delete #{service_name} DNS record" do
 	EOS
 end
 
-execute "Archive remaining logs" do
+bash "Archive remaining logs" do
 	user "solr"
 	cwd "/"
-	command "gzip /var/solr/logs/*log; /usr/local/bin/archive-solr-logs.sh"
+	code <<-EOS
+		TIMESTAMP=`date +'%s'`
+		for logfile in `ls -d /var/log/solr/*log`; do
+			mv "$logfile" "$logfile.$TIMESTAMP"
+			gzip "$logfile.$TIMESTAMP"
+		done
+		/usr/local/bin/archive-logs.sh solr
+	EOS
 end

--- a/templates/default/archive-solr-logs.sh.erb
+++ b/templates/default/archive-solr-logs.sh.erb
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-SERVICE="solr"
-LOG_DIR="/var/$SERVICE/logs/" ./archive-logs.sh $SERVICE


### PR DESCRIPTION
Move Solr logs from `/var/solr/logs` (which is actually on the EFS) to `/var/log/solr`.