### PR TITLE
[QOL-5604] use en_GB instead of en

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -181,7 +181,7 @@ ckanext.validation.formats = csv xlsx xls
 
 ## Internationalisation Settings
 
-ckan.locale_default = en
+ckan.locale_default = en_AU
 ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
 ckan.locales_offered =
 ckan.locales_filtered_out =


### PR DESCRIPTION
- CKAN doesn't have a definition for 'en' so it uses defaults, which are more like US English