### PR TITLE
[QOL-5350] drop undesirable unzip flag

### DIFF
--- a/recipes/solr-deploycore.rb
+++ b/recipes/solr-deploycore.rb
@@ -54,7 +54,7 @@ end
 
 execute 'Unzip Core Config' do
 	user 'root'
-	command "unzip -u -q -f -o #{Chef::Config[:file_cache_path]}/solr_core_config.zip -d #{solr_core_dir}"
+	command "unzip -u -q -o #{Chef::Config[:file_cache_path]}/solr_core_config.zip -d #{solr_core_dir}"
 end
 
 service "solr" do


### PR DESCRIPTION
We want the `-u` flag, to unzip new files and freshen existing ones, not the `-f` flag, which doesn't unzip new ones.