### PR TITLE
[QOL-5879] use 'simple' full-text search

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -208,6 +208,7 @@ ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru 
 ckan.locales_offered =
 ckan.locales_filtered_out =
 ckan.display_timezone = server
+ckan.datastore.default_fts_lang=simple
 
 ## Feeds Settings
 


### PR DESCRIPTION
- The default 'english' search often doesn't work properly, especially with non-standard words like scientific names