### PR TITLE
[QOL-6190] put XLoader into compatibility mode for easier migration

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -260,6 +260,8 @@ ckan.datapusher.url = http://<%= node['datashades']['app_id'] %>datapusher.<%= n
 
 ckan.redis.url = redis://<%= node['datashades']['redis']['hostname'] %>:<%= node['datashades']['redis']['port'] %>/0
 
+ckanext.xloader.compatibility_mode = True
+
 ## Activity Streams Settings
 
 ckan.activity_streams_enabled = true


### PR DESCRIPTION
- a lot of our most critical data uses non-ISO dates that can't be parsed without messytables anyway