### PR TITLE
[QOL-5710] allow cookie-based authentication for autocomplete APIs

### DIFF
--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -22,8 +22,8 @@
     RewriteCond %{REQUEST_URI} ^/(ar|bg|ca|cs_CZ|da_DK|de|el|en|en_AU|en_GB|es|es_AR|fa_IR|fi|fr|he|hr|hu|id|is|it|ja|km|ko_KR|lt|lv|mn_MN|ne|nl|no|pl|pt_BR|pt_PT|ro|ru|sk|sl|sq|sr|sr_Latn|sv|th|tr|uk_UA|vi|zh_CN|zh_TW)/(.*) [NC]
     RewriteRule / "/%2" [R]
 
-    # API should not respect auth_tkt cookies, it should require the API key.
-    <Location ~ /api/(?!storage|action/(package_resource_reorder|resource_view_reorder|[-_a-zA-Z0-9]*follow)) >
+    # API calls with significant side effects should not respect auth_tkt cookies, they should require the API key.
+    <Location ~ /api/(?!storage|action/(package_resource_reorder|resource_view_reorder|[-_a-zA-Z0-9]*follow)|([12]/)?util/[a-z]+/(format_)?autocomplete) >
         RequestHeader unset Cookie
     </Location>
 


### PR DESCRIPTION
- this will allow us to lock down the user list API to authorised users