### PR TITLE
[QOL-6483] add Unix socket config so that supervisorctl works

### DIFF
--- a/files/default/supervisor-ckan-worker.conf
+++ b/files/default/supervisor-ckan-worker.conf
@@ -1,3 +1,9 @@
+[unix_http_server]
+file=/var/tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 ; =======================================================
 ; Supervisor configuration for CKAN background job worker
 ; =======================================================


### PR DESCRIPTION
With this change, we will be able to use commands like `sudo supervisorctl restart ckan-worker:ckan-worker-00` to restart the individual worker, instead of having to restart the entire Supervisor process.