### PR TITLE
[QOL-6710] drop regex groups since they interfere with the replacement

### DIFF
--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -20,8 +20,8 @@
 
     # Rewrite to remove locale
 
-    RewriteCond %{REQUEST_URI} ^/(a[fmrsz]|ar_(AE|BH|DZ|EG|IQ|JO|KW|LB|LY|MA|OM|QA|SA|SY|TN|YE)|az_AZ|b[egnos]|c[asy]|cs_CZ|d[aev]|da_DK|de_(AT|CH|DE|LI|LU)|e[lnstu]|en_(AU|BZ|CA|CB|GB|IE|IN|JM|NZ|PH|TT|US|ZA)|es_(AR|BO|C[LOR]|DO|EC|ES|GT|HN|MX|NI|P[AERY]|SV|UY|VE)|f[aior]|fa_IR|fr_(BE|CA|CH|FR|LU)|g[dlnu]|gd_IE|h[eiruy]|i[dst]|it_CH|it_IT|ja|k[akmnos]|ko_KR|l[aotv]|m[iklnrsty]|mn_MN|ms_BN|ms_MY|n[elo]|nl_BE|nl_NL|no_NO|or|p[alt]|pt_BR|pt_PT|r[mou]|ro_MO|ru_MO|s[abdikloqrvw]|sr_Latn|sr_SP|sv_FI|sv_SE|t[aeghklnrst]|u[krz]|uk_UA|uz_UZ|vi|xh|yi|zh|zh_(CN|HK|MO|SG|TW)|zu)/(.*) [NC]
-    RewriteRule / "/%2" [R]
+    RewriteCond %{REQUEST_URI} ^/(a[fmrsz]|b[egnos]|c[asy]|d[aev]|e[lnstu]|f[aior]|g[dlnu]|h[eiruy]|i[dst]|ja|k[akmnos]|l[aotv]|m[iklnrsty]|n[elo]|or|p[alt]|r[mou]|s[abdikloqrvw]|sr_Latn|t[aeghklnrst]|u[krz]|vi|xh|yi|z[hu])(_[A-Z][A-Z])?/(.*) [NC]
+    RewriteRule / "/%3" [R]
 
     # API calls with significant side effects should not respect auth_tkt cookies, they should require the API key.
     <Location ~ /api/(?!storage|action/(package_resource_reorder|resource_view_reorder|[-_a-zA-Z0-9]*follow)|([12]/)?util/[a-z]+/(format_)?autocomplete) >


### PR DESCRIPTION
- need to have the same number of replacement groups on all branches
- also simplify the regex by consistently handling all region specifiers (eg en_AU, en_UK) for each language