### PR TITLE
[QOL-7007] increase resource size limit to 250MB

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -222,7 +222,7 @@ ckan.feeds.author_link =
 
 ## Storage Settings
 
-ckan.max_resource_size = 200
+ckan.max_resource_size = 250
 ckan.max_image_size = 10
 ckan.storage_path = /var/shared_content/<%= @app_name %>/ckan_storage
 


### PR DESCRIPTION
Needed for Public Trust to upload their "unclaimed money" data.