### PR TITLE
[DQL2-13] don't specify the 'stopwaitsecs' property

### DIFF
--- a/files/default/supervisor-ckan-harvest-fetch.conf
+++ b/files/default/supervisor-ckan-harvest-fetch.conf
@@ -41,7 +41,3 @@ autorestart=true
 ; Number of seconds the process has to run before it is considered to have
 ; started successfully.
 startsecs=10
-
-; Need to wait for currently executing tasks to finish at shutdown.
-; Increase this if you have very long running tasks.
-stopwaitsecs = 600

--- a/files/default/supervisor-ckan-harvest-gather.conf
+++ b/files/default/supervisor-ckan-harvest-gather.conf
@@ -41,7 +41,3 @@ autorestart=true
 ; Number of seconds the process has to run before it is considered to have
 ; started successfully.
 startsecs=10
-
-; Need to wait for currently executing tasks to finish at shutdown.
-; Increase this if you have very long running tasks.
-stopwaitsecs = 600


### PR DESCRIPTION
The docs don't say to use it, and it seems to interfere with proper shutdown of the fetch consumer