### PR TITLE
DQL2-6 enable db init, ordering and extra worker install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+*.iml

--- a/files/default/supervisor-ckan-archiver.conf
+++ b/files/default/supervisor-ckan-archiver.conf
@@ -1,0 +1,81 @@
+[unix_http_server]
+file=/var/tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+; ======================================================================
+; Supervisor configuration for CKAN Archiver background bulk jobs worker
+; ======================================================================
+
+; 1. Copy this file to /etc/supervisor/conf.d
+; 2. Make sure the paths below match your setup
+
+
+[program:ckan-worker-bulk]
+
+; Use the full paths to the virtualenv and your configuration file here.
+command=/usr/lib/ckan/default/bin/paster --plugin=ckan jobs worker bulk --config=/etc/ckan/default/production.ini
+
+
+; User the jobs bulk worker runs as.
+user=ckan
+
+
+; Start just a single jobs bulk worker.
+numprocs=1
+process_name=%(program_name)s-%(process_num)02d
+
+
+; Log files.
+stdout_logfile=/var/log/ckan/ckan-worker-bulk.log
+stderr_logfile=/var/log/ckan/ckan-worker-bulk.log
+
+
+; Make sure that the jobs bulk worker is started on system start and automatically
+; restarted if it crashes unexpectedly.
+autostart=true
+autorestart=true
+
+
+; Number of seconds the process has to run before it is considered to have
+; started successfully.
+startsecs=10
+
+; ==========================================================================
+; Supervisor configuration for CKAN Archiver background priority jobs worker
+; ==========================================================================
+
+; 1. Copy this file to /etc/supervisor/conf.d
+; 2. Make sure the paths below match your setup
+
+
+[program:ckan-worker-priority]
+
+; Use the full paths to the virtualenv and your configuration file here.
+command=/usr/lib/ckan/default/bin/paster --plugin=ckan jobs worker priority --config=/etc/ckan/default/production.ini
+
+
+; User the jobs priority worker runs as.
+user=ckan
+
+
+; Start just a single jobs priority worker.
+numprocs=1
+process_name=%(program_name)s-%(process_num)02d
+
+
+; Log files.
+stdout_logfile=/var/log/ckan/ckan-worker-priority.log
+stderr_logfile=/var/log/ckan/ckan-worker-priority.log
+
+
+; Make sure that the jobs priority worker is started on system start and automatically
+; restarted if it crashes unexpectedly.
+autostart=true
+autorestart=true
+
+
+; Number of seconds the process has to run before it is considered to have
+; started successfully.
+startsecs=10

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -89,7 +89,10 @@ extordering =
 	'odi_certificates' => 20,
 	'dcat structured_data' => 30,
 	'data_qld data_qld_google_analytics' => 40,
-	'scheming_datasets' => 50
+	'scheming_datasets' => 50,
+	'qa' => 60,
+	'archiver' => 70,
+	'report' => 80
 }
 
 installed_ordered_exts = Set[]
@@ -100,15 +103,16 @@ node['datashades']['ckan_ext']['packages'].each do |p|
 	package p
 end
 
+## TODO work out how to purge when harvester extension is not found
 # Strip out existing config in case it's no longer used
 #
-execute "Clean Harvest supervisor config" do
-	command "rm -f /etc/supervisor/conf.d/supervisor-ckan-harvest*.conf"
-end
-
-execute "Clean Harvest cron" do
-	command "rm -f /etc/cron.*/ckan-harvest*"
-end
+#execute "Clean Harvest supervisor config" do
+#	command "rm -f /etc/supervisor/conf.d/supervisor-ckan-harvest*.conf"
+#end
+#
+#execute "Clean Harvest cron" do
+#	command "rm -f /etc/cron.*/ckan-harvest*"
+#end
 
 # Do the actual extension installation using pip
 #
@@ -275,6 +279,32 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 			file "/etc/cron.hourly/ckan-harvest-run" do
 				content "/usr/local/bin/pick-job-server.sh && #{virtualenv_dir}/bin/paster --plugin=ckanext-harvest harvester run -c #{config_dir}/production.ini 2>&1 > /dev/null\n"
 				mode "0755"
+			end
+		end
+
+		if "#{pluginname}".eql? 'archiver'
+			execute "Archiver CKAN ext database init" do
+				user "#{account_name}"
+				command "#{virtualenv_dir}/bin/paster --plugin=ckanext-archiver archiver init  -c #{config_dir}/production.ini || echo 'Ignoring expected error'"
+			end
+
+			cookbook_file "/etc/supervisor/conf.d/supervisor-ckan-archiver.conf" do
+				source "supervisor-ckan-harvest.conf"
+				mode "0744"
+			end
+		end
+
+		if "#{pluginname}".eql? 'qa'
+			execute "qa CKAN ext database init" do
+				user "#{account_name}"
+				command "#{virtualenv_dir}/bin/paster --plugin=ckanext-qa qa init  -c #{config_dir}/production.ini || echo 'Ignoring expected error'"
+			end
+		end
+
+		if "#{pluginname}".eql? 'report'
+			execute "report CKAN ext database init" do
+				user "#{account_name}"
+				command "#{virtualenv_dir}/bin/paster --plugin=ckanext-report report init  -c #{config_dir}/production.ini || echo 'Ignoring expected error'"
 			end
 		end
 

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -289,7 +289,7 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 			end
 
 			cookbook_file "/etc/supervisor/conf.d/supervisor-ckan-archiver.conf" do
-				source "supervisor-ckan-harvest.conf"
+				source "supervisor-ckan-archiver.conf"
 				mode "0744"
 			end
 		end

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -241,6 +241,13 @@ ckanext.cloudstorage.container_name = <%= node['datashades']['attachments_bucket
 ckanext.cloudstorage.driver_options = use_role
 ckanext.cloudstorage.use_secure_urls = 1
 
+
+ckanext-archiver.archive_dir = /resource_cache
+ckanext-archiver.cache_url_root = /resource_cache
+ckanext-archiver.max_content_length = 250000000
+ckanext-archiver.user_agent_string = "CKAN archiver https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>"
+ckanext-archiver.verify_https = True
+
 ## Cache
 ckan.cache_enabled = True
 ckan.static_max_age = 1800

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -243,7 +243,7 @@ ckanext.cloudstorage.use_secure_urls = 1
 
 
 #the plan; instead of on disk, we will be using the uploader, once we work out to get files dynamically from it
-ckanext-archiver.archive_dir = /data/resource_cache
+ckanext-archiver.archive_dir = /var/shared_content/<%= @app_name %>/resource_cache
 #the plan; drop this for patten /dataset/{id}/resource/{resource_id}/archive/{filename}
 ckanext-archiver.cache_url_root = /resource_cache
 ckanext-archiver.max_content_length = 250000000

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -242,7 +242,9 @@ ckanext.cloudstorage.driver_options = use_role
 ckanext.cloudstorage.use_secure_urls = 1
 
 
-ckanext-archiver.archive_dir = /resource_cache
+#the plan; instead of on disk, we will be using the uploader, once we work out to get files dynamically from it
+ckanext-archiver.archive_dir = /data/resource_cache
+#the plan; drop this for patten /dataset/{id}/resource/{resource_id}/archive/{filename}
 ckanext-archiver.cache_url_root = /resource_cache
 ckanext-archiver.max_content_length = 250000000
 ckanext-archiver.user_agent_string = "CKAN archiver https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>"


### PR DESCRIPTION
Here’s the minimum requirements for adding the QA/5 Star related extensions to the cookbook & infrastructure:

Extensions
http://github.com/okfn/ckanext-qa.git - we will need to fork this to apply custom scoring rules around validated resources, so might as well fork it now into qld-gov-au and we’ll fork from there.

http://github.com/datagovuk/ckanext-report.git

http://github.com/ckan/ckanext-archiver.git

Neither of those two use releases/tags, so just point to master branch.

CKAN ini file changes
ckan.plugins = ...  qa archiver report
(in that specific order)

# Archiver
ckanext-archiver.archive_dir = /app/filestore/archive
ckanext-archiver.cache_url_root = http://dataqld-ckan.docker.amazee.io/resources/
^ These two will need some experimenting in relation to your use of S3 uploads and their settings.

Supervisor processes
Two new job worker queues are created by the archiver extension, so these need job worker processes setup:

paster --plugin=ckan jobs worker bulk -c /path/to/production.ini

paster --plugin=ckan jobs worker priority -c /path/to/production.ini 
Database tables
The following paster initialisation commands need to be run:

# Initialise the ckanext-report tables
paster --plugin=ckanext-report report initdb -c /path/to/production.ini

# Initialise the ckanext-archiver tables
paster --plugin=ckanext-archiver archiver init -c /path/to/production.ini

# Initialise the ckanext-qa tables
paster --plugin=ckanext-qa qa init -c /path/to/production.ini