### PR TITLE
Qol 7096 server restarts

### DIFF
--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -54,6 +54,9 @@ default['datashades']['ckan_web']['auth']['roles_that_cascade_to_sub_groups'] = 
 default['datashades']['ckan_web']['google']['gtm_container_id'] = ''
 default['datashades']['ckan_web']['google']['analytics_id'] = 'UA-7276966-12'
 
+default['datashades']['ckan_web']['wsgi']['processes'] = '1'
+default['datashades']['ckan_web']['wsgi']['threads'] = '15'
+
 default['datashades']['ckan_ext']['packages'] = ['geos-devel.x86_64', 'npm']
 
 default['datashades']['postgres']['password'] = ""

--- a/files/default/httpd-reload-on-low-memory
+++ b/files/default/httpd-reload-on-low-memory
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Check the amount of free memory (including disk cache and buffers);
+# if it's less than 500MB, and Apache is running, then reload Apache.
+# Not an ideal solution to memory leaks, but it's a universal one.
+free -m |head -3 |tail -1 |awk '{print $4}' |grep '^[5-9][0-9][0-9]' > /dev/null || (service httpd status > /dev/null && service httpd reload)

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -277,7 +277,7 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 
 			# only have one server trigger harvest initiation, which then worker queues harvester fetch/gather works through the queues.
 			file "/etc/cron.hourly/ckan-harvest-run" do
-				content "/usr/local/bin/pick-job-server.sh && #{virtualenv_dir}/bin/paster --plugin=ckanext-harvest harvester run -c #{config_dir}/production.ini 2>&1 > /dev/null\n"
+				content "/usr/local/bin/pick-job-server.sh && #{virtualenv_dir}/bin/paster --plugin=ckanext-harvest harvester run -c #{config_dir}/production.ini > /dev/null 2>&1\n"
 				mode "0755"
 			end
 		end

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -314,7 +314,7 @@ end
 
 # Only set cron job for lower environments
 file '/etc/cron.hourly/ckan-tracking-update' do
-	content "/usr/local/bin/pick-job-server.sh && #{paster} tracking update -c #{config_file} 2>&1 >/dev/null\n"
+	content "/usr/local/bin/pick-job-server.sh && #{paster} tracking update -c #{config_file} >/dev/null 2>&1\n"
 	mode '0755'
 	owner "root"
 	group "root"
@@ -323,7 +323,7 @@ end
 
 # Run tracking update at 8:30am everywhere
 file "/etc/cron.d/ckan-tracking-update" do
-	content "30 8 * * * root /usr/local/bin/pick-job-server.sh && #{paster} tracking update -c #{config_file} 2>&1 >/dev/null\n"
+	content "30 8 * * * root /usr/local/bin/pick-job-server.sh && #{paster} tracking update -c #{config_file} >/dev/null 2>&1\n"
 	mode '0755'
 	owner "root"
 	group "root"
@@ -331,7 +331,7 @@ end
 
 
 file "/etc/cron.hourly/ckan-email-notifications" do
-	content "/usr/local/bin/pick-job-server.sh && echo '{}' | #{paster} post -c #{config_file} /api/action/send_email_notifications 2>&1 > /dev/null\n"
+	content "/usr/local/bin/pick-job-server.sh && echo '{}' | #{paster} post -c #{config_file} /api/action/send_email_notifications > /dev/null 2>&1\n"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -40,7 +40,7 @@ end
 # however, if logs in subdirectories are already compressed by logrotate,
 # then they will be archived too.
 file "/etc/cron.daily/archive-system-logs-to-s3" do
-	content "LOG_DIR=/var/log /usr/local/bin/archive-logs.sh system 2>&1 >/dev/null\n"
+	content "LOG_DIR=/var/log /usr/local/bin/archive-logs.sh system >/dev/null 2>&1\n"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/recipes/httpd-configure.rb
+++ b/recipes/httpd-configure.rb
@@ -45,7 +45,7 @@ end
 # Reload Apache periodically if we have memory leaks.
 # Not an ideal solution, but a universal one.
 file '/etc/cron.hourly/httpd-reload-on-low-memory' do
-	content "free -m |head -3 |tail -1 |awk '{print $4}' |grep '^[4-9][0-9][0-9]' > /dev/null || (service httpd status > /dev/null && service httpd reload)"
+	content "free -m |head -3 |tail -1 |awk '{print $4}' |grep '^[5-9][0-9][0-9]' > /dev/null || (service httpd status > /dev/null && service httpd reload)"
 	mode "0755"
 	owner "root"
 	group "root"

--- a/recipes/httpd-configure.rb
+++ b/recipes/httpd-configure.rb
@@ -41,3 +41,12 @@ service 'httpd' do
 	supports :restart => true, :reload => true, :status => true
 	action [:enable, :start, :reload]
 end
+
+# Reload Apache periodically if we have memory leaks.
+# Not an ideal solution, but a universal one.
+file '/etc/cron.hourly/httpd-reload-on-low-memory' do
+	content "free -m |head -3 |tail -1 |awk '{print $4}' |grep '^[4-9][0-9][0-9]' > /dev/null || (service httpd status > /dev/null && service httpd reload)"
+	mode "0755"
+	owner "root"
+	group "root"
+end

--- a/recipes/httpd-configure.rb
+++ b/recipes/httpd-configure.rb
@@ -30,7 +30,7 @@ execute "Extend Apache log rotation" do
 end
 
 file "/etc/cron.daily/archive-apache-logs-to-s3" do
-	content "/usr/local/bin/archive-logs.sh httpd 2>&1 >/dev/null\n"
+	content "/usr/local/bin/archive-logs.sh httpd >/dev/null 2>&1\n"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/recipes/httpd-configure.rb
+++ b/recipes/httpd-configure.rb
@@ -42,10 +42,8 @@ service 'httpd' do
 	action [:enable, :start, :reload]
 end
 
-# Reload Apache periodically if we have memory leaks.
-# Not an ideal solution, but a universal one.
-file '/etc/cron.hourly/httpd-reload-on-low-memory' do
-	content "free -m |head -3 |tail -1 |awk '{print $4}' |grep '^[5-9][0-9][0-9]' > /dev/null || (service httpd status > /dev/null && service httpd reload)"
+cookbook_file '/etc/cron.hourly/httpd-reload-on-low-memory' do
+	source "httpd-reload-on-low-memory"
 	mode "0755"
 	owner "root"
 	group "root"

--- a/recipes/nginx-configure.rb
+++ b/recipes/nginx-configure.rb
@@ -30,7 +30,7 @@ execute "Extend Nginx log rotation" do
 end
 
 file "/etc/cron.daily/archive-nginx-logs-to-s3" do
-	content "/usr/local/bin/archive-logs.sh nginx 2>&1 >/dev/null\n"
+	content "/usr/local/bin/archive-logs.sh nginx >/dev/null 2>&1\n"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -32,7 +32,7 @@ template "/usr/local/bin/solr-healthcheck.sh" do
 end
 
 file "/etc/cron.daily/archive-solr-logs-to-s3" do
-	content "/usr/local/bin/archive-logs.sh #{service_name} 2>&1 >/dev/null\n"
+	content "/usr/local/bin/archive-logs.sh #{service_name} >/dev/null 2>&1\n"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -12,7 +12,7 @@
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
-    WSGIDaemonProcess ckan_default display-name=ckan_default processes=1 threads=15
+    WSGIDaemonProcess ckan_default display-name=ckan_default processes=<%= node['datashades']['ckan_web']['wsgi']['processes'] %> threads=<%= node['datashades']['ckan_web']['wsgi']['threads'] %>
 
     WSGIProcessGroup ckan_default
 

--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -12,7 +12,7 @@
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
-    WSGIDaemonProcess ckan_default display-name=ckan_default processes=2 threads=15
+    WSGIDaemonProcess ckan_default display-name=ckan_default processes=1 threads=15
 
     WSGIProcessGroup ckan_default
 


### PR DESCRIPTION
- Reduce WSGI processes per server to limit memory usage.
- Reload Apache if free memory is too low, in case of memory leaks.