### PR TITLE
Openess score config

### DIFF
--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -131,6 +131,7 @@ template "#{config_file}" do
 	variables({
 		:app_name =>  app['shortname'],
 		:app_url => app['domains'][0],
+		:src_dir => "#{virtualenv_dir}/src",
 		:email_domain => node['datashades']['ckan_web']['email_domain']
 	})
 	action :create

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -127,7 +127,7 @@ ckan.harvest.mq.hostname = <%= node['datashades']['redis']['hostname'] %>
 ckan.harvest.mq.port = <%= node['datashades']['redis']['port'] %>
 
 ## QA
-qa.resource_format_openness_scores_json = /usr/lib/ckan/default/src/ckanext-data-qld/ckanext/data_qld/resource_format_openness_scores.json
+qa.resource_format_openness_scores_json = <%= @src_dir %>/ckanext-data-qld/ckanext/data_qld/resource_format_openness_scores.json
 
 ## Google Analytics
 googleanalytics.id = UA-7276966-13
@@ -195,7 +195,7 @@ ckan.comments.moderation.first_only = False
 ckan.comments.threaded_comments = True
 ckan.comments.users_can_edit = False
 ckan.comments.check_for_profanity = True
-ckan.comments.bad_words_file = /usr/lib/ckan/default/src/ckanext-ytp-comments/ckanext/ytp/comments/bad_words.txt
+ckan.comments.bad_words_file = <%= @src_dir %>/ckanext-ytp-comments/ckanext/ytp/comments/bad_words.txt
 ckan.comments.follow_mute_enabled = True
 ckan.comments.show_comments_tab_page = True
 

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -126,6 +126,9 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = <%= node['datashades']['redis']['hostname'] %>
 ckan.harvest.mq.port = <%= node['datashades']['redis']['port'] %>
 
+## QA
+qa.resource_format_openness_scores_json = /usr/lib/ckan/default/src/ckanext-data-qld/ckanext/data_qld/resource_format_openness_scores.json
+
 ## Google Analytics
 googleanalytics.id = UA-7276966-13
 googleanalytics.track_frontend_events = false


### PR DESCRIPTION
There is one CKAN config value you will need to add to your cookbook for the 5-star rating system deployment. Please update the extension file path to match your infrastructure setup.

# QA
qa.resource_format_openness_scores_json = /app/src/ckanext-data-qld/ckanext/data_qld/resource_format_openness_scores.json
This uses data-qld specific custom score rules for file formats and will need to be deployed with the qld-gov-au/ckanext-qa and qld-gov-au/ckanext-data-qld changes in the PRs.