### PR TITLE
[QOL-6815] ensure we use the correct CKAN egg metadata for our branch

### DIFF
--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -67,7 +67,8 @@ apprelease = app['app_source']['url']
 
 if app['app_source']['type'].eql? "git" then
 	version = app['app_source']['revision']
-else
+end
+if not version then
 	apprelease.sub! "#{service_name}/archive/", "#{service_name}.git@"
 	apprelease.sub! '.zip', ""
 	version = apprelease[/@(.*)/].sub! '@', ''
@@ -99,7 +100,7 @@ bash "Check out selected revision" do
 	cwd "#{install_dir}"
 	code <<-EOS
                 # retrieve latest branch metadata
-		git fetch
+		git fetch origin '#{version}'
                 # drop unversioned files
 		git clean
                 # make versioned files pristine

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -97,13 +97,20 @@ bash "Check out selected revision" do
 	user "#{service_name}"
 	group "#{service_name}"
 	cwd "#{install_dir}"
-	# pull if we're checking out a branch, otherwise it doesn't matter
 	code <<-EOS
+                # retrieve latest branch metadata
 		git fetch
+                # drop unversioned files
+		git clean
+                # make versioned files pristine
 		git reset --hard
 		git checkout '#{version}'
+	        # get latest changes if we're checking out a branch, otherwise it doesn't matter
 		git pull
+                # drop compiled files from previous branch
 		find . -name '*.pyc' -delete
+                # regenerate metadata
+                #{virtualenv_dir}/bin/python setup.py develop
 	EOS
 end
 


### PR DESCRIPTION
- Without this, we just rely on the initially generated metadata from 'master', which may not be correct.