### PR TITLE
clean up version extraction

### DIFF
--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -123,15 +123,14 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 	pluginname = "#{app['shortname']}".sub(/.*ckanext-/, "")
 
 	apprevision = app['app_source']['revision']
-	if ! apprevision
-		apprevision = "master"
-	end
+	apprevision ||= app['app_source']['url'][/@(.*)/].sub '@', ''
+	apprevision ||= "master"
 
 	# Don't install extensions not required by the batch node
 	#
 	installext = !batchnode || (batchnode && batchexts.include?(pluginname))
 	unless (!installext)
-		apprelease = app['app_source']['url'].sub 'http', "git+http"
+		apprelease = app['app_source']['url'].sub('http', "git+http").sub(/@(.*)/, '')
 
 		if app['app_source']['type'].casecmp("git") == 0 then
 			apprelease << "@#{apprevision}"

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -63,16 +63,15 @@ directory "#{shared_fs_dir}/private" do
 	action :create
 end
 
-apprelease = app['app_source']['url']
-
+# Get the version number from the app revision, by preference,
+# or from the app URL if revision is not defined.
+# Either way, ensure that the version number is stripped from the URL.
 if app['app_source']['type'].eql? "git" then
 	version = app['app_source']['revision']
 end
-if not version then
-	apprelease.sub! "#{service_name}/archive/", "#{service_name}.git@"
-	apprelease.sub! '.zip', ""
-	version = apprelease[/@(.*)/].sub! '@', ''
-end
+apprelease = app['app_source']['url'].sub("#{service_name}/archive/", "#{service_name}.git@").sub('.zip', "")
+urlrevision = apprelease[/@(.*)/].sub! '@', ''
+version ||= urlrevision
 version ||= "master"
 
 #


### PR DESCRIPTION
- recognise version in source URL for CKAN extensions
- ensure that the version is stripped from the URL before appending another