### PR TITLE
[QOL-7306] fix tar arguments for backing up to S3

### DIFF
--- a/templates/default/solr-sync.sh.erb
+++ b/templates/default/solr-sync.sh.erb
@@ -28,7 +28,7 @@ if (/usr/local/bin/pick-solr-master.sh); then
   done
   if [ "$MINUTE" = "00" ]; then
     cd "$LOCAL_DIR"
-    tar czf "$SNAPSHOT_NAME.tgz" "$SNAPSHOT_NAME"
+    tar --force-local -czf "$SNAPSHOT_NAME.tgz" "$SNAPSHOT_NAME"
     aws s3 mv "$SNAPSHOT_NAME.tgz" "s3://$BUCKET/solr_backup/$CORE_NAME/" --expires $(date -d '30 days' --iso-8601=seconds)
     sudo -u solr rm -r snapshot.$CORE_NAME-*
   fi


### PR DESCRIPTION
- force-local to make tar ignore colons
- missed a hyphen in the creation arguments