### PR TITLE
Qol 4841 Update DNS dynamically based on current primary

### DIFF
--- a/files/default/updatedns
+++ b/files/default/updatedns
@@ -42,9 +42,12 @@ function update_dns
 	# Create cluster alias records as applicable
 	#
 	if [[ "${dns_type}" == *"_master"*  ]]; then
-		cli53 rrcreate -i ${dns_type} --failover PRIMARY --replace ${tld} "${alias} AWS ALIAS CNAME ${name} \$self true"
+		failover_type=PRIMARY
 	elif [[ "${dns_type}" == *"_slave"*  ]]; then
-		cli53 rrcreate -i ${dns_type} --failover SECONDARY --replace ${tld} "${alias} AWS ALIAS CNAME ${name} \$self true"
+		failover_type=SECONDARY
+	fi
+	if [ "$failover_type" != "" ]; then
+		aws route53 change-resource-record-sets --hosted-zone-id ${zone_id} --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"${alias}.${tld}\",\"Type\":\"CNAME\",\"SetIdentifier\":\"${dns_type}\",\"Failover\":\"${failover_type}\",\"AliasTarget\":{\"HostedZoneId\":\"${zone_id}\",\"DNSName\":\"${name}.${tld}\",\"EvaluateTargetHealth\":true}}}]}"
 	fi
 
 }

--- a/files/default/updatedns
+++ b/files/default/updatedns
@@ -42,9 +42,9 @@ function update_dns
 	# Create cluster alias records as applicable
 	#
 	if [[ "${dns_type}" == *"_master"*  ]]; then
-		cli53 rrcreate -i ${dns_type} --failover PRIMARY ${tld} "${alias} AWS ALIAS CNAME ${name} \$self true"
+		cli53 rrcreate -i ${dns_type} --failover PRIMARY --replace ${tld} "${alias} AWS ALIAS CNAME ${name} \$self true"
 	elif [[ "${dns_type}" == *"_slave"*  ]]; then
-		cli53 rrcreate -i ${dns_type} --failover SECONDARY ${tld} "${alias} AWS ALIAS CNAME ${name} \$self true"
+		cli53 rrcreate -i ${dns_type} --failover SECONDARY --replace ${tld} "${alias} AWS ALIAS CNAME ${name} \$self true"
 	fi
 
 }

--- a/recipes/autoupdatedns.rb
+++ b/recipes/autoupdatedns.rb
@@ -22,7 +22,7 @@
 
 # Create script to auto update DNS on OpsWorks configure events
 #
-cookbook_file '/sbin/updatedns' do
+cookbook_file '/bin/updatedns' do
   source 'updatedns'
   owner 'root'
   group 'root'

--- a/recipes/ckanweb-setup.rb
+++ b/recipes/ckanweb-setup.rb
@@ -25,7 +25,7 @@ include_recipe "datashades::default"
 
 # Create ASG helper script
 #
-cookbook_file "/sbin/updateasg" do
+cookbook_file "/bin/updateasg" do
 	source "updateasg"
 	owner 'root'
 	group 'root'

--- a/recipes/datapusher-setup.rb
+++ b/recipes/datapusher-setup.rb
@@ -108,7 +108,7 @@ bash "Add #{service_name} DNS entry" do
 	EOS
 end
 
-cookbook_file '/sbin/updatedns' do
+cookbook_file '/bin/updatedns' do
 	source 'updatedns'
 	owner 'root'
 	group 'root'
@@ -116,7 +116,7 @@ cookbook_file '/sbin/updatedns' do
 end
 
 execute "Update #{node['datashades']['hostname']} #{service_name} DNS" do
-	command	'/sbin/updatedns'
+	command	'/bin/updatedns'
 	user 'root'
 	group 'root'
 end

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -22,12 +22,6 @@
 
 include_recipe "datashades::stackparams"
 
-template "/usr/local/sbin/archive-logs.sh" do
-	source "archive-logs.sh.erb"
-	owner "root"
-	group "root"
-	mode "0755"
-end
 template "/usr/local/bin/archive-logs.sh" do
 	source "archive-logs.sh.erb"
 	owner "root"
@@ -49,10 +43,10 @@ end
 # Run updateDNS script
 #
 execute 'update dns' do
-	command	'/sbin/updatedns'
+	command	'/bin/updatedns'
 	user 'root'
 	group 'root'
-	not_if { ! ::File.directory? "/sbin/updatedns" }
+	only_if { ::File.exist? "/bin/updatedns" }
 end
 
 # Update custom auditd rules

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -129,14 +129,6 @@ bash "Adding AWS ZoneID" do
 	EOS
 end
 
-# Install cli53 for Failover recordset creation
-#
-remote_file "/bin/cli53" do
-	source "https://github.com/barnybug/cli53/releases/download/0.8.5/cli53-linux-amd64"
-	owner 'root'
-	mode '0755'
-end
-
 # Create DNS helper script
 #
 cookbook_file "/bin/checkdns" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -131,7 +131,7 @@ end
 
 # Install cli53 for Failover recordset creation
 #
-remote_file "/sbin/cli53" do
+remote_file "/bin/cli53" do
 	source "https://github.com/barnybug/cli53/releases/download/0.8.5/cli53-linux-amd64"
 	owner 'root'
 	mode '0755'
@@ -139,7 +139,7 @@ end
 
 # Create DNS helper script
 #
-cookbook_file "/sbin/checkdns" do
+cookbook_file "/bin/checkdns" do
 	source "checkdns"
 	owner 'root'
 	group 'root'

--- a/recipes/nfs-setup.rb
+++ b/recipes/nfs-setup.rb
@@ -43,7 +43,7 @@ end
 
 # Create script to update DNS on configure events
 #
-cookbook_file '/sbin/updatedns' do
+cookbook_file '/bin/updatedns' do
   source 'updatedns'
   owner 'root'
   group 'root'
@@ -53,7 +53,7 @@ end
 # Run updateDNS script
 #
 execute "Update #{node['datashades']['hostname']} #{service_name} DNS" do
-  command	'/sbin/updatedns'
+  command	'/bin/updatedns'
   user 'root'
   group 'root'
 end

--- a/recipes/postgres-setup.rb
+++ b/recipes/postgres-setup.rb
@@ -54,7 +54,7 @@ end
 
 # Create script to update DNS on configure events
 #
-cookbook_file '/sbin/updatedns' do
+cookbook_file '/bin/updatedns' do
 	source 'updatedns'
 	owner 'root'
 	group 'root'
@@ -64,7 +64,7 @@ end
 # Run updateDNS script
 #
 execute "Update #{node['datashades']['hostname']} #{service_name} DNS" do
-	command	'/sbin/updatedns'
+	command	'/bin/updatedns'
 	user 'root'
 	group 'root'
 end

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -97,7 +97,7 @@ bash "Add #{service_name} DNS entry" do
 	EOS
 end
 
-cookbook_file '/sbin/updatedns' do
+cookbook_file '/bin/updatedns' do
 	source 'updatedns'
 	owner 'root'
 	group 'root'

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -83,17 +83,16 @@ end
 bash "Add #{service_name} DNS entry" do
 	user "root"
 	code <<-EOS
-		zoneid=$(aws route53 list-hosted-zones-by-name --dns-name "#{node['datashades']['tld']}" | jq '.HostedZones[0].Id' | tr -d '"/hostedzone')
-		reccount=$(aws route53 list-resource-record-sets --hosted-zone-id $zoneid --query "ResourceRecordSets[?contains(Name, '#{node['datashades']['version']}#{service_name}')].Name" | jq '. | length')
-		aliascount=$(aws route53 list-resource-record-sets --hosted-zone-id $zoneid --query "ResourceRecordSets[?contains(Name, '#{node['datashades']['version']}#{service_name}.')].Name" | jq '. | length')
-		hostcount=`expr $reccount - $aliascount + 1`
-		echo ${hostcount} > /etc/#{service_name}id
+		server_id=$(echo "#{node['datashades']['hostname']}" |tr -cd '[[:digit:]]')
+		echo "${server_id}" > /etc/#{service_name}id
 		sed -i "/#{service_name}_/d" /etc/hostnames
-		if [ ${hostcount} -eq 1 ]; then
-			echo "#{service_name}_master=#{node['datashades']['app_id']}#{service_name}${hostcount}.#{node['datashades']['tld']}" >> /etc/hostnames
+		if [ "${server_id}" -eq 1 ]; then
+			failover_type=master
 		else
-			echo "#{service_name}_slave=#{node['datashades']['app_id']}#{service_name}${hostcount}.#{node['datashades']['tld']}" >> /etc/hostnames
+			failover_type=slave
 		fi
+		alias="#{node['datashades']['app_id']}#{service_name}${server_id}.#{node['datashades']['tld']}"
+		echo "#{service_name}_${failover_type}=${alias}" >> /etc/hostnames
 	EOS
 end
 
@@ -102,12 +101,6 @@ cookbook_file '/bin/updatedns' do
 	owner 'root'
 	group 'root'
 	mode '0755'
-end
-
-execute "Update #{node['datashades']['hostname']} #{service_name} DNS" do
-	command	'/sbin/updatedns'
-	user 'root'
-	group 'root'
 end
 
 service "solr" do

--- a/templates/default/solr-sync.sh.erb
+++ b/templates/default/solr-sync.sh.erb
@@ -16,6 +16,8 @@ if ! (curl -I "$HOST/$CORE_NAME/admin/ping" 2>/dev/null |grep '200 OK' > /dev/nu
     exit 0
 fi
 if (/usr/local/bin/pick-solr-master.sh); then
+  sed -i 's/^solr_slave=/solr_master=/' /etc/hostnames
+  updatedns &
   curl "$HOST/$CORE_NAME/replication?command=backup&location=$LOCAL_DIR&name=$BACKUP_NAME"
   sleep 5
   sudo -u solr rsync -a --delete "$LOCAL_SNAPSHOT" "$SYNC_SNAPSHOT" || exit 1
@@ -40,4 +42,6 @@ else
     sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT" "$LOCAL_SNAPSHOT" || exit 1
     curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
   fi
+  sed -i 's/^solr_master=/solr_slave=/' /etc/hostnames
+  updatedns &
 fi

--- a/templates/default/solr-sync.sh.erb
+++ b/templates/default/solr-sync.sh.erb
@@ -11,13 +11,22 @@ HOST="http://localhost:8983/solr"
 BUCKET="<%= node['datashades']['log_bucket'] %>"
 MINUTE=$(date +%M)
 
+function set_dns_primary () {
+  if [ "$1" = "true" ]; then
+    sed -i 's/^solr_slave=/solr_master=/' /etc/hostnames
+  else
+    sed -i 's/^solr_master=/solr_slave=/' /etc/hostnames
+  fi
+  updatedns &
+}
+
 # we can't perform any replication operations if Solr is stopped
 if ! (curl -I "$HOST/$CORE_NAME/admin/ping" 2>/dev/null |grep '200 OK' > /dev/null); then
-    exit 0
+  set_dns_primary false
+  exit 0
 fi
 if (/usr/local/bin/pick-solr-master.sh); then
-  sed -i 's/^solr_slave=/solr_master=/' /etc/hostnames
-  updatedns &
+  set_dns_primary true
   curl "$HOST/$CORE_NAME/replication?command=backup&location=$LOCAL_DIR&name=$BACKUP_NAME"
   sleep 5
   sudo -u solr rsync -a --delete "$LOCAL_SNAPSHOT" "$SYNC_SNAPSHOT" || exit 1
@@ -35,6 +44,7 @@ if (/usr/local/bin/pick-solr-master.sh); then
     sudo -u solr rm -r snapshot.$CORE_NAME-*
   fi
 else
+  set_dns_primary false
   # Give the master time to update the sync copy
   sleep 10
   if [ -d "$SYNC_SNAPSHOT" ]; then
@@ -42,6 +52,4 @@ else
     sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT" "$LOCAL_SNAPSHOT" || exit 1
     curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
   fi
-  sed -i 's/^solr_master=/solr_slave=/' /etc/hostnames
-  updatedns &
 fi


### PR DESCRIPTION
This adjusts and repurposes the existing DNS configuration code to update it as needed each minute. It is capable of both automatic and manual failover between two Solr instances.

Caveats:
- The sync script only runs each minute. Changes made during this window may be lost, by being sent to a server that then becomes the secondary and gets overwritten before it can update the sync copy.
- The DNS primary/secondary configuration is not currently capable of having more than two servers in the pool. This might be resolvable by someone with more DNS expertise.
- Servers must use the same OpsWorks naming scheme, eg opendata-solr1, opendata-solr2. Current Open Data production has a misnamed legacy server, 'opendata-datapusher1'.