### PR TITLE
Dc 18845 delay swap configuration until 'setup'

### DIFF
--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -28,6 +28,7 @@ if ::File.directory?(extra_disk) then
 	bash "Add swap disk" do
 		code <<-EOS
 			dd if=/dev/zero of=#{swap_file} bs=1024 count=1M
+			chmod 0600 #{swap_file}
 			mkswap #{swap_file}
 		EOS
 		not_if { ::File.exist?(swap_file) }

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -35,7 +35,7 @@ if ::File.directory?(extra_disk) then
 	end
 
 	execute "Enable swap disk" do
-		command "swapon #{swap_file}"
+		command "swapon -s | grep '^#{swap_file} ' || swapon #{swap_file}"
 	end
 end
 

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -29,16 +29,12 @@ if ::File.directory?(extra_disk) then
 		code <<-EOS
 			dd if=/dev/zero of=#{swap_file} bs=1024 count=1M
 			mkswap #{swap_file}
-			swapon #{swap_file}
 		EOS
 		not_if { ::File.exist?(swap_file) }
 	end
 
-	bash "Enable swap disk on boot" do
-		code <<-EOS
-			sed -i '\\|^#{swap_file} |d' /etc/fstab
-			echo '#{swap_file} swap swap defaults 0 2' >> /etc/fstab
-		EOS
+	execute "Enable swap disk" do
+		command "swapon #{swap_file}"
 	end
 end
 


### PR DESCRIPTION
The extra swap space isn't available until disks are mounted, and isn't urgent at boot time, so it shouldn't be in /etc/fstab