### PR TITLE
[QOL-6491] set up Squid proxy to block downloading from private addresses

### DIFF
--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -22,7 +22,7 @@
 #
 
 default['datashades']['ckan_web']['endpoint'] = '/'
-default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'postgresql94-devel', 'postgresql94', 'python27-devel', 'python27-pip', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'gcc', 'gcc-c++', 'make', 'java-1.8.0-openjdk-devel', 'java-1.8.0-openjdk', 'xalan-j2', 'unzip', 'policycoreutils-python', 'mod24_wsgi-python27', 'supervisor']
+default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'postgresql94-devel', 'postgresql94', 'python27-devel', 'python27-pip', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'gcc', 'gcc-c++', 'make', 'java-1.8.0-openjdk-devel', 'java-1.8.0-openjdk', 'xalan-j2', 'unzip', 'policycoreutils-python', 'mod24_wsgi-python27', 'supervisor', 'squid']
 
 default['datashades']['ckan_web']['dbuser'] = 'ckan_default'
 default['datashades']['ckan_web']['dbname'] = 'ckan_default'

--- a/files/default/squid.conf
+++ b/files/default/squid.conf
@@ -8,8 +8,11 @@ acl to_localnet dst fc00::/7              # RFC 4193 local private network range
 acl to_localnet dst fe80::/10             # RFC 4291 link-local (directly plugged) machines
 
 acl SSL_ports port 443
+acl SSL_ports port 8443
 acl Safe_ports port 80
 acl Safe_ports port 443
+acl Safe_ports port 8080
+acl Safe_ports port 8443
 acl CONNECT method CONNECT
 
 http_access deny !Safe_ports

--- a/files/default/squid.conf
+++ b/files/default/squid.conf
@@ -1,0 +1,23 @@
+acl to_localnet dst 0.0.0.1-0.255.255.255 # RFC 1122 "this" network (LAN)
+acl to_localnet dst 10.0.0.0/8            # RFC 1918 local private network (LAN)
+acl to_localnet dst 100.64.0.0/10         # RFC 6598 shared address space (CGN)
+acl to_localnet dst 169.254.0.0/16        # RFC 3927 link-local (directly plugged) machines
+acl to_localnet dst 172.16.0.0/12         # RFC 1918 local private network (LAN)
+acl to_localnet dst 192.168.0.0/16        # RFC 1918 local private network (LAN)
+acl to_localnet dst fc00::/7              # RFC 4193 local private network range
+acl to_localnet dst fe80::/10             # RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access deny manager
+http_access deny to_localhost
+http_access deny to_localnet
+http_access allow localhost
+http_access deny all
+
+http_port 127.0.0.1:3128

--- a/recipes/ckanweb-configure.rb
+++ b/recipes/ckanweb-configure.rb
@@ -21,6 +21,7 @@
 # limitations under the License.
 
 include_recipe "datashades::default-configure"
+include_recipe "datashades::squid-configure"
 
 # Fix Amazon PYTHON_INSTALL_LAYOUT so items are installed in sites/packages not distr/packages
 #

--- a/recipes/squid-configure.rb
+++ b/recipes/squid-configure.rb
@@ -1,0 +1,33 @@
+#
+# Author:: Carl Antuar (<carl.antuar@smartservice.qld.gov.au>)
+# Cookbook Name:: datashades
+# Recipe:: squid-configure
+#
+# Configures Squid proxy server to blacklist private addresses.
+#
+# Copyright 2021, Queensland Government
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cookbook_file '/etc/squid/squid.conf' do
+	source 'squid.conf'
+	owner 'root'
+	group 'root'
+	mode '0755'
+end
+
+service "squid" do
+	supports :restart => true, :reload => true, :status => true
+	action [:enable, :start, :reload]
+end

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -250,6 +250,9 @@ ckanext.cloudstorage.driver_options = use_role
 ckanext.cloudstorage.use_secure_urls = 1
 
 
+# download resources via Squid so we can block internal and private addresses
+ckan.download_proxy = http://localhost:3128
+
 #the plan; instead of on disk, we will be using the uploader, once we work out to get files dynamically from it
 ckanext-archiver.archive_dir = /var/shared_content/<%= @app_name %>/resource_cache
 #the plan; drop this for patten /dataset/{id}/resource/{resource_id}/archive/{filename}


### PR DESCRIPTION
This will only affect extensions that support the 'ckan.download_proxy' property.