### PR TITLE
[QOL-7737] add config settings to support legacy Pairtree storage

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -231,6 +231,8 @@ ckan.feeds.author_link =
 
 ckan.max_resource_size = 250
 ckan.max_image_size = 10
+ofs.impl = pairtree
+ofs.storage_dir = /var/shared_content/<%= @app_name %>/ckan_storage
 ckan.storage_path = /var/shared_content/<%= @app_name %>/ckan_storage
 
 ## S3 Storage Settings


### PR DESCRIPTION
- this still doesn't seem to be enough to actually serve objects from the Pairtree filestore,
but it will help support our new Paster command to get them into S3.