### PR TITLE
[QOL-7841] clean up unnecessary function whitelisting config

### DIFF
--- a/files/default/allowed_functions.txt
+++ b/files/default/allowed_functions.txt
@@ -280,8 +280,4 @@ xmlcomment
 xmlconcat
 xpath
 xpath_exists
-COUNT
 ictdashboards_tables
-MAX
-MIN
-SUM

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -440,25 +440,33 @@ end
 
 # Enable DataStore and DataPusher extensions if desired
 # No installation necessary in CKAN 2.2+
-bash "Enable DataStore-related extensions" do
-	user "ckan"
-	cwd "#{config_dir}"
-	code <<-EOS
-		if [ -z  "$(grep 'ckan.plugins.*datastore' production.ini)" ]; then
-			sed -i "/^ckan.plugins/ s/$/ datastore/" production.ini
-		fi
-	EOS
-	only_if { "yes".eql? node['datashades']['ckan_web']['dsenable']}
+if "yes".eql? node['datashades']['ckan_web']['dsenable'] do
+	bash "Enable DataStore-related extensions" do
+		user "ckan"
+		cwd "#{config_dir}"
+		code <<-EOS
+			if [ -z  "$(grep 'ckan.plugins.*datastore' production.ini)" ]; then
+				sed -i "/^ckan.plugins/ s/$/ datastore/" production.ini
+			fi
+		EOS
+	end
+
+	cookbook_file "#{config_dir}/allowed_functions.txt" do
+		source 'allowed_functions.txt'
+		owner "#{service_name}"
+		group "#{service_name}"
+		mode "0755"
+	end
+
+	# There is a race condition when uploading a resource; the page tries
+	# to display it, while the DataPusher tries to delete and recreate it.
+	# Thus, the resource may not exist when the page loads.
+	# See https://github.com/ckan/ckan/issues/3980
+	execute "Patch upload race condition" do
+		user "#{account_name}"
+		command <<-'SED'.strip + " #{virtualenv_dir}/src/ckan/ckan/lib/helpers.py"
+			sed -i "s/^\(\s\{4\}\)\(result = logic.get_action('datastore_search')({}, data)\)/\1import ckan.plugins as p\n\1try:\n\1\1\2\n\1except p.toolkit.ObjectNotFound:\n\1\1return []/"
+		SED
+	end
 end
 
-# There is a race condition when uploading a resource; the page tries
-# to display it, while the DataPusher tries to delete and recreate it.
-# Thus, the resource may not exist when the page loads.
-# See https://github.com/ckan/ckan/issues/3980
-execute "Patch upload race condition" do
-	user "#{account_name}"
-	command <<-'SED'.strip + " #{virtualenv_dir}/src/ckan/ckan/lib/helpers.py"
-		sed -i "s/^\(\s\{4\}\)\(result = logic.get_action('datastore_search')({}, data)\)/\1import ckan.plugins as p\n\1try:\n\1\1\2\n\1except p.toolkit.ObjectNotFound:\n\1\1return []/"
-	SED
-	only_if { "yes".eql? node['datashades']['ckan_web']['dsenable']}
-end

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -186,13 +186,6 @@ link "#{config_dir}/who.ini" do
 	link_type :symbolic
 end
 
-cookbook_file "#{config_dir}/allowed_functions.txt" do
-	source 'allowed_functions.txt'
-	owner "#{service_name}"
-	group "#{service_name}"
-	mode "0755"
-end
-
 #
 # Initialise data
 #

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -67,8 +67,10 @@ who.log_file = %(cache_dir)s/who_log.ini
 ## Database Settings
 sqlalchemy.url = postgresql://<%= node['datashades']['ckan_web']['dbuser'] %>:<%= node['datashades']['postgres']['password'] %>@<%= node['datashades']['version'] %>pg.<%= node['datashades']['tld'] %>/<%= node['datashades']['ckan_web']['dbname'] %>
 
+<% if 'yes'.eql(node['datashades']['ckan_web']['dsenable']) -%>
 ckan.datastore.write_url = postgresql://<%= node['datashades']['ckan_web']['dbuser'] %>:<%= node['datashades']['postgres']['password'] %>@<%= node['datashades']['version'] %>pg.<%= node['datashades']['tld'] %>/<%= node['datashades']['ckan_web']['dsname'] %>
 ckan.datastore.read_url = postgresql://<%= node['datashades']['ckan_web']['dsuser'] %>:<%= node['datashades']['postgres']['password'] %>@<%= node['datashades']['version'] %>pg.<%= node['datashades']['tld'] %>/<%= node['datashades']['ckan_web']['dsname'] %>
+
 # XLoader can share the main database, but NOT the datastore
 # See https://github.com/ckan/ckanext-xloader/issues/17 and https://github.com/ckan/ckanext-xloader/issues/83
 ckanext.xloader.jobs_db.uri = postgresql://<%= node['datashades']['ckan_web']['dbuser'] %>:<%= node['datashades']['postgres']['password'] %>@<%= node['datashades']['version'] %>pg.<%= node['datashades']['tld'] %>/<%= node['datashades']['ckan_web']['dbname'] %>
@@ -76,6 +78,7 @@ ckanext.xloader.jobs_db.uri = postgresql://<%= node['datashades']['ckan_web']['d
 # We need the SQL endpoint, despite the non-ideal security implications
 ckan.datastore.sqlsearch.enabled = True
 ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/allowed_functions.txt
+<% end -%>
 
 ## Site Settings
 


### PR DESCRIPTION
- only configure the whitelist if we're enabling the Datastore
- no need for uppercase entries since we're patching CKAN to treat the list as case-insensitive