### PR TITLE
[QOL-7934] remove our 'ckan_cli' helper from the process tree once it launches a child

### DIFF
--- a/files/default/ckan_cli
+++ b/files/default/ckan_cli
@@ -58,10 +58,10 @@ fi
 
 if [ "$COMMAND" = "ckan" ]; then
     echo "Using 'ckan' command from $ENV_DIR..." >&2
-    $ENV_DIR/ckan -c ${CKAN_INI_FILE} "$@"
+    exec $ENV_DIR/ckan -c ${CKAN_INI_FILE} "$@"
 elif [ "$COMMAND" = "paster" ]; then
     echo "Using 'paster' command from $ENV_DIR..." >&2
-    $ENV_DIR/paster --plugin=$PASTER_PLUGIN "$@" -c ${CKAN_INI_FILE}
+    exec $ENV_DIR/paster --plugin=$PASTER_PLUGIN "$@" -c ${CKAN_INI_FILE}
 else
     echo "Unable to locate 'ckan' or 'paster' command in $ENV_DIR" >&2
     exit 1


### PR DESCRIPTION
This will work better with Supervisor, which doesn't handle grandchildren very gracefully.
Otherwise we get orphaned 'paster' processes, with ckan_cli stopped but paster still running.