### PR TITLE
Develop to master

### DIFF
--- a/files/default/ckan_cli
+++ b/files/default/ckan_cli
@@ -58,10 +58,10 @@ fi
 
 if [ "$COMMAND" = "ckan" ]; then
     echo "Using 'ckan' command from $ENV_DIR..." >&2
-    $ENV_DIR/ckan -c ${CKAN_INI_FILE} "$@"
+    exec $ENV_DIR/ckan -c ${CKAN_INI_FILE} "$@"
 elif [ "$COMMAND" = "paster" ]; then
     echo "Using 'paster' command from $ENV_DIR..." >&2
-    $ENV_DIR/paster --plugin=$PASTER_PLUGIN "$@" -c ${CKAN_INI_FILE}
+    exec $ENV_DIR/paster --plugin=$PASTER_PLUGIN "$@" -c ${CKAN_INI_FILE}
 else
     echo "Unable to locate 'ckan' or 'paster' command in $ENV_DIR" >&2
     exit 1

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -143,10 +143,15 @@ directory "#{efs_data_dir}/data/#{core_name}/data" do
     recursive true
 end
 
-datashades_move_and_link(efs_data_dir) do
-    target real_data_dir
-    client_service service_name
-    owner service_name
+# copy EFS contents if we need them, but don't alter them
+if not ::File.identical?(real_data_dir, var_data_dir) then
+    service service_name do
+        action [:stop]
+    end
+    execute "rsync -a #{efs_data_dir}/ #{real_data_dir}/" do
+        user service_name
+        only_if { ::File.directory? efs_data_dir }
+    end
 end
 
 datashades_move_and_link(var_data_dir) do

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -86,7 +86,6 @@ end
 extra_disk = "/mnt/local_data"
 extra_disk_present = ::File.exist? extra_disk
 
-# move Solr onto extra EBS disk
 efs_data_dir = "/data/#{service_name}"
 var_data_dir = "/var/#{service_name}"
 var_log_dir = "/var/#{service_name}/logs"
@@ -96,33 +95,6 @@ if extra_disk_present then
 else
     real_data_dir = efs_data_dir
     real_log_dir = var_log_dir
-end
-
-directory real_data_dir do
-    owner account_name
-    group "ec2-user"
-    mode "0775"
-    action :create
-end
-
-directory "#{efs_data_dir}/data/#{core_name}/data" do
-    owner account_name
-    group "ec2-user"
-    mode "0775"
-    action :create
-    recursive true
-end
-
-datashades_move_and_link(efs_data_dir) do
-    target real_data_dir
-    client_service service_name
-    owner service_name
-end
-
-datashades_move_and_link(var_data_dir) do
-    target real_data_dir
-    client_service service_name
-    owner service_name
 end
 
 # move logs off root disk
@@ -150,6 +122,35 @@ end
 efs_log_dir = "#{efs_data_dir}/logs"
 datashades_move_and_link(efs_log_dir) do
     target real_log_dir
+    client_service service_name
+    owner service_name
+end
+
+# move Solr core onto extra EBS disk
+
+directory real_data_dir do
+    owner account_name
+    group "ec2-user"
+    mode "0775"
+    action :create
+end
+
+directory "#{efs_data_dir}/data/#{core_name}/data" do
+    owner account_name
+    group "ec2-user"
+    mode "0775"
+    action :create
+    recursive true
+end
+
+datashades_move_and_link(efs_data_dir) do
+    target real_data_dir
+    client_service service_name
+    owner service_name
+end
+
+datashades_move_and_link(var_data_dir) do
+    target real_data_dir
     client_service service_name
     owner service_name
 end

--- a/resources/pip_install_app.rb
+++ b/resources/pip_install_app.rb
@@ -41,7 +41,6 @@ action :create do
     # Either way, ensure that the version number is stripped from the URL.
     if is_git then
         version = new_resource.revision
-        apprelease.sub!('http', "git+http")
         apprelease.sub!("#{new_resource.service_name}/archive/", "#{new_resource.service_name}.git@")
         apprelease.sub!('.zip', "")
     end
@@ -67,6 +66,7 @@ action :create do
         end
     else
         if is_git then
+            apprelease.sub!('^http:', "git+http:")
             apprelease << "@#{version}"
         end
         if ! apprelease.include? '#egg' then
@@ -87,7 +87,7 @@ action :create do
             # retrieve latest branch metadata
             git fetch origin '#{version}'
             # drop unversioned files
-            git clean
+            git clean -f
             # make versioned files pristine
             git reset --hard
             git checkout '#{version}'


### PR DESCRIPTION
Fix errors introduced by 5.0.0

- Pip installation sets incorrect Git origin URL (protocol should be 'https' not 'git+https')
- `git clean` needs the `-f` flag to work non-interactively.
- EFS solr data should be copied to EBS, not moved.