### PR TITLE
[QOL-7857] handle HTTPS Git URLs as well as HTTP

### DIFF
--- a/resources/pip_install_app.rb
+++ b/resources/pip_install_app.rb
@@ -66,7 +66,7 @@ action :create do
         end
     else
         if is_git then
-            apprelease.sub!('^http:', "git+http:")
+            apprelease.sub!('^http', "git+http")
             apprelease << "@#{version}"
         end
         if ! apprelease.include? '#egg' then


### PR DESCRIPTION
This doesn't affect already-installed eggs but is necessary on fresh installations.