### PR TITLE
[DC-22846] increase organisation list limit so our site isn't truncated

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -283,6 +283,8 @@ ckan.use_pylons_response_cleanup_middleware = true
 ## Make ckan commit changes solr after every dataset update change.
 ##Turn this to False if on solr 4.0 and you have automatic (soft)commits enabled
 ##ckan.search.solr_commit = True
+# Group/organisation list is computation-intensive, so it is truncated
+ckan.group_and_organization_list_all_fields_max = 100
 
 ## Datapusher settings
 


### PR DESCRIPTION
Ideally we should replace the `organization_list` calls, but this is the most reliable fix for now.