### PR TITLE
[QOL-8060] improve Solr failover reliability

### DIFF
--- a/templates/default/pick-solr-master.sh.erb
+++ b/templates/default/pick-solr-master.sh.erb
@@ -2,23 +2,40 @@
 
 # Identify whether the current server is the Solr master.
 
+function is_healthy() {
+  HEALTH_FILE=$1
+  IGNORE_STARTUP=$2
+  if [ ! -e "$HEALTH_FILE" ]; then
+    return 1
+  fi
+  if [ -e "$HEALTH_FILE.start" ] && [ "$IGNORE_STARTUP" != "true" ]; then
+    return 1
+  fi
+  HEALTH_TIME=$(cat $1 | tr -d '[:space:]')
+  if [ "$HEALTH_TIME" = "" ]; then
+    return 1
+  fi
+  AGE=$(expr $NOW - $HEALTH_TIME)
+  return $(expr $AGE '>' $MAX_AGE)
+}
+
 opsworks_hostname="<%= node['datashades']['hostname'] %>"
 layer_prefix=$(echo "$opsworks_hostname" | tr -d '[0-9]')
 NOW=$(date +'%s')
 MAX_AGE=120
 for i in {9..1}; do
   SERVER_NAME="$layer_prefix$i"
-  HEALTH_FILE="/data/solr-healthcheck_$SERVER_NAME"
-  if [ -e "$HEALTH_FILE" ]; then
-    HEALTH_TIME=$(cat $HEALTH_FILE | tr -d '[:space:]')
-    if [ "$HEALTH_TIME" = "" ]; then
-        continue
-    fi
-    AGE=$(expr $NOW - $HEALTH_TIME)
-    HEALTHY=$(expr $AGE '<=' $MAX_AGE)
-    if [ "$HEALTHY" = "1" ]; then
-      SELECTED_SERVER="$SERVER_NAME"
-    fi
+  if is_healthy "/data/solr-healthcheck_$SERVER_NAME"; then
+    SELECTED_SERVER="$SERVER_NAME"
   fi
 done
+# if we have no master, try grabbing one that's only passed a single health check
+if [ "$SELECTED_SERVER" = "" ]; then
+  for i in {9..1}; do
+    SERVER_NAME="$layer_prefix$i"
+    if is_healthy "/data/solr-healthcheck_$SERVER_NAME" true; then
+      SELECTED_SERVER="$SERVER_NAME"
+    fi
+  done
+fi
 exit $([ "$SELECTED_SERVER" = "$opsworks_hostname" ])

--- a/templates/default/solr-healthcheck.sh.erb
+++ b/templates/default/solr-healthcheck.sh.erb
@@ -1,12 +1,26 @@
 #!/bin/sh
 
 HEARTBEAT_FILE="/data/solr-healthcheck_<%= node['datashades']['hostname'] %>"
+# If present, this file marks a server as "just started, may not be updated, don't use yet"
+STARTUP_FILE="$HEARTBEAT_FILE.start"
 # Only update heartbeat if it is present.
 # This allows us to manually drop a server from the pool
 if [ -e "$HEARTBEAT_FILE" ]; then
-  CURRENT_TIME=`date +%s`
+  CURRENT_TIME=$(date +%s)
   if (curl -I "http://localhost:8983/solr/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/admin/ping" 2>/dev/null |grep '200 OK' > /dev/null); then
+    PREVIOUS_HEALTH_TIME=$(cat $HEARTBEAT_FILE | tr -d '[:space:]')
     echo $CURRENT_TIME > "$HEARTBEAT_FILE"
+    if [ "$PREVIOUS_HEALTH_TIME" = "" ]; then
+      IS_HEALTHY=0
+    else
+      AGE=$(expr $CURRENT_TIME - $PREVIOUS_HEALTH_TIME)
+      IS_HEALTHY=$(expr $AGE '>' $MAX_AGE)
+    fi
+    if $IS_HEALTHY; then
+      rm -f $STARTUP_FILE
+    else
+      touch $STARTUP_FILE
+    fi
   else
     exit 1
   fi


### PR DESCRIPTION
Make Solr instances pass two health checks, not one, to become master, unless there is no viable candidate.