### PR TITLE
[QOL-8104] stop robots from indexing resource download URLs

### DIFF
--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -42,7 +42,7 @@
     Redirect /organization/science-information-technology-innovation-and-the-arts /organization/science-information-technology-and-innovation
     Redirect /organization/state-development-infrastructure-and-planning /organization/state-development
 
-    SetEnvIf Request_URI "/dataset/[^/]+/resource/[^/]+/download/" file_download=1
+    SetEnvIf Request_URI "/<%= node['datashades']['attachments_bucket'] %>/" file_download=1
     Header always set X-Robots-Tag "noindex,nofollow" env=file_download
 
     Header always set Strict-Transport-Security "max-age=31536000"

--- a/templates/default/apache_ckan.conf.erb
+++ b/templates/default/apache_ckan.conf.erb
@@ -42,6 +42,9 @@
     Redirect /organization/science-information-technology-innovation-and-the-arts /organization/science-information-technology-and-innovation
     Redirect /organization/state-development-infrastructure-and-planning /organization/state-development
 
+    SetEnvIf Request_URI "/dataset/[^/]+/resource/[^/]+/download/" file_download=1
+    Header always set X-Robots-Tag "noindex,nofollow" env=file_download
+
     Header always set Strict-Transport-Security "max-age=31536000"
     Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
 


### PR DESCRIPTION
- These will often be presigned S3 URLs, which are temporary and so shouldn't be indexed.
Even if they're not, the actual file download isn't the best option to index;
the resource page is the appropriate landing point.