### PR TITLE
[DQL3-52] cron job into cookbook

### DIFF
--- a/recipes/ckanbatch-deploy.rb
+++ b/recipes/ckanbatch-deploy.rb
@@ -122,12 +122,14 @@ file "/etc/cron.d/ckan-tracking-update" do
 end
 
 # Run dataset require updates notifications at 7am and 7:15am on batch
-file "/etc/cron.d/ckan-dataset-notification-due" do
-    content "00 7 * * * root /usr/local/bin/pick-job-server.sh && PASTER_PLUGIN=ckanext-data-qld #{ckan_cli} send_email_dataset_due_to_publishing_notification >/dev/null 2>&1\n"\
-            "15 7 * * * root /usr/local/bin/pick-job-server.sh && PASTER_PLUGIN=ckanext-data-qld #{ckan_cli} send_email_dataset_overdue_notification >/dev/null 2>&1\n"
-    mode '0644'
-    owner "root"
-    group "root"
+if File.foreach(config_file).grep(/^\s*ckan[.]plugins\s*=.*\bdata_qld(_integration)?\b/).any?
+    file "/etc/cron.d/ckan-dataset-notification-due" do
+        content "00 7 * * * root /usr/local/bin/pick-job-server.sh && PASTER_PLUGIN=ckanext-data-qld #{ckan_cli} send_email_dataset_due_to_publishing_notification >/dev/null 2>&1\n"\
+                "15 7 * * * root /usr/local/bin/pick-job-server.sh && PASTER_PLUGIN=ckanext-data-qld #{ckan_cli} send_email_dataset_overdue_notification >/dev/null 2>&1\n"
+        mode '0644'
+        owner "root"
+        group "root"
+    end
 end
 
 file "/etc/cron.hourly/ckan-email-notifications" do


### PR DESCRIPTION
per https://github.com/qld-gov-au/ckanext-data-qld/pull/108

For Email dataset currency notifications there are two paster commands to send the emails. They will need to be set up on a weekly cron schedule of 7 am Monday Brisbane time.
Datasets Due
{activate_virtual_env} && paster --plugin=ckanext-data-qld send_email_dataset_due_to_publishing_notification -c <ckan_ini_file_path>
Datasets Overdue
{activate_virtual_env} && paster --plugin=ckanext-data-qld send_email_dataset_overdue_notification -c <ckan_ini_file_path>