### PR TITLE
QOL-8406 fix solr health checks

### DIFF
--- a/files/default/awslogs.conf
+++ b/files/default/awslogs.conf
@@ -1,0 +1,2 @@
+[general]
+state_file = /var/lib/awslogs/agent-state

--- a/files/default/awslogs.conf
+++ b/files/default/awslogs.conf
@@ -1,2 +1,0 @@
-[general]
-state_file = /var/lib/awslogs/agent-state

--- a/files/default/pick-solr-master.sh
+++ b/files/default/pick-solr-master.sh
@@ -2,6 +2,8 @@
 
 # Identify whether the current server is the Solr master.
 
+. `dirname $0`/solr-env.sh
+
 function is_healthy() {
   HEALTH_FILE=$1
   IGNORE_STARTUP=$2
@@ -19,7 +21,6 @@ function is_healthy() {
   return $(expr $AGE '>' $MAX_AGE)
 }
 
-opsworks_hostname="<%= node['datashades']['hostname'] %>"
 layer_prefix=$(echo "$opsworks_hostname" | tr -d '[0-9]')
 NOW=$(date +'%s')
 MAX_AGE=120

--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -49,10 +49,10 @@ is_ping_healthy () {
 is_index_healthy () {
   curl "$HOST/$CORE_NAME/replication?command=backup&location=/tmp&name=health_check" 2>/dev/null \
     |grep '"status": *"OK"' > /dev/null || return 1
-  if ! (sudo -u solr sh -c "$LUCENE_CHECK $BACKUP_DIR >> $LOG_FILE"); then
-    rm -rf "$BACKUP_DIR"
-    return 1
-  fi
+  sudo -u solr sh -c "$LUCENE_CHECK $BACKUP_DIR >> $LOG_FILE"
+  IS_HEALTHY=$?
+  rm -rf "$BACKUP_DIR"
+  return $IS_HEALTHY
 }
 
 is_healthy () {

--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -49,8 +49,11 @@ is_ping_healthy () {
 is_index_healthy () {
   curl "$HOST/$CORE_NAME/replication?command=backup&location=/tmp&name=health_check" 2>/dev/null \
     |grep '"status": *"OK"' > /dev/null || return 1
-  sudo -u solr sh -c "$LUCENE_CHECK $BACKUP_DIR >> $LOG_FILE"
   IS_HEALTHY=$?
+  if [ "$IS_HEALTHY" = "0" ]; then
+    sudo -u solr sh -c "$LUCENE_CHECK $BACKUP_DIR >> $LOG_FILE"
+    IS_HEALTHY=$?
+  fi
   rm -rf "$BACKUP_DIR"
   return $IS_HEALTHY
 }

--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -3,17 +3,10 @@
 # ensure we can still grab the correct exit code after piping output to 'tee'
 set +o pipefail
 
-MAX_AGE=120
-HEARTBEAT_FILE="/data/solr-healthcheck_<%= node['datashades']['hostname'] %>"
-# If present, this file marks a server as "just started, may not be updated, don't use yet"
-STARTUP_FILE="$HEARTBEAT_FILE.start"
+. `dirname $0`/solr-env.sh
 
-CORE_NAME="<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>"
-HOST="http://localhost:8983/solr"
-PING_URL="$HOST/$CORE_NAME/admin/ping"
-DATA_DIR="/mnt/local_data/solr_data/data/$CORE_NAME/data"
-LUCENE_JAR=$(ls /opt/solr/server/solr-webapp/webapp/WEB-INF/lib/lucene-core-*.jar | tail -1)
-LUCENE_CHECK="java -cp $LUCENE_JAR -ea:org.apache.lucene... org.apache.lucene.index.CheckIndex"
+MAX_AGE=120
+
 LOG_FILE="/var/log/solr/solr_${CORE_NAME}_health-check.log"
 BACKUP_DIR="/tmp/snapshot.health_check"
 
@@ -31,10 +24,20 @@ fix_index () {
   fi
   INDEX_DIR="$DATA_DIR/$INDEX_DIR"
   # Attempt to exorcise index corruption.
-  # If even that fails, move the whole index aside for later forensics.
-  # (Solr should recreate it and try to recover from the master sync.)
-  sudo -u solr sh -c "$LUCENE_CHECK -exorcise $INDEX_DIR >> $LOG_FILE \
-    || mv -v $INDEX_DIR $INDEX_DIR.bad.`date +'%s'` >> $LOG_FILE"
+  # If even that fails, move the whole index aside for later forensics
+  # and copy a fresh index from the EFS sync.
+  if ! (sudo -u solr sh -c "$LUCENE_CHECK $INDEX_DIR >> $LOG_FILE"); then
+    # Lucene returns an error code if the index was bad,
+    # even if it was successfully exorcised,
+    # so check again to determine whether we actually succeeded.
+    sudo -u solr sh -c "(echo 'Index failed check, attempting to fix'; \
+        $LUCENE_CHECK -exorcise $INDEX_DIR; $LUCENE_CHECK $INDEX_DIR || \
+            (echo 'Index is unrecoverable, copy from backup'; \
+            mv $INDEX_DIR $INDEX_DIR.bad.`date +'%s'` && \
+            rm $DATA_DIR/index.properties && \
+            rsync -a --delete $SYNC_DIR/index/ $DATA_DIR/index') \
+        ) >> $LOG_FILE"
+  fi
   sudo service solr start
   touch $HEARTBEAT_FILE
 }

--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -48,7 +48,7 @@ is_ping_healthy () {
 
 is_index_healthy () {
   curl "$HOST/$CORE_NAME/replication?command=backup&location=/tmp&name=health_check" 2>/dev/null \
-    |grep '"status": *"OK"' > /dev/null || return 1
+    |grep '"status": *"OK"' > /dev/null
   IS_HEALTHY=$?
   if [ "$IS_HEALTHY" = "0" ]; then
     sudo -u solr sh -c "$LUCENE_CHECK $BACKUP_DIR >> $LOG_FILE"

--- a/files/default/solr-is-up.sh
+++ b/files/default/solr-is-up.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+HEARTBEAT_FILE="/data/solr-healthcheck_<%= node['datashades']['hostname'] %>"
+# Only update heartbeat if it is present.
+# This allows us to manually drop a server from the pool
+if [ -e "$HEARTBEAT_FILE" ]; then
+  CURRENT_TIME=`date +%s`
+  if (curl -I "http://localhost:8983/solr/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/admin/ping" 2>/dev/null |grep '200 OK' > /dev/null); then
+    echo $CURRENT_TIME > "$HEARTBEAT_FILE"
+  else
+    exit 1
+  fi
+fi

--- a/files/default/toggle-solr-healthcheck.sh
+++ b/files/default/toggle-solr-healthcheck.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. `dirname $0`/solr-env.sh
+
 usage () {
   echo "Usage: $0 on|off"
   exit 1
@@ -8,7 +10,6 @@ if [ "$#" -lt 1 ]; then
   usage
 fi
 COMMAND="$1"
-HEARTBEAT_FILE="/data/solr-healthcheck_<%= node['datashades']['hostname'] %>"
 if [ "$COMMAND" = "on" ]; then
   sudo touch $HEARTBEAT_FILE
 elif [ "$COMMAND" = "off" ]; then

--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -18,6 +18,23 @@
 
 include_recipe "datashades::ckan-configure"
 
+extra_disk = "/mnt/local_data"
+if ::File.directory?(extra_disk) then
+    swap_file = "#{extra_disk}/swapfile_2g"
+    bash "Add swap disk" do
+        code <<-EOS
+            dd if=/dev/zero of=#{swap_file} bs=1024 count=2M
+            chmod 0600 #{swap_file}
+            mkswap #{swap_file}
+        EOS
+        not_if { ::File.exist?(swap_file) }
+    end
+
+    execute "Enable swap disk" do
+        command "swapon -s | grep '^#{swap_file} ' || swapon #{swap_file}"
+    end
+end
+
 service "supervisord" do
     action [:stop, :start]
 end

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -24,29 +24,36 @@ include_recipe "datashades::default-configure"
 
 service_name = 'solr'
 
-template "/usr/local/bin/solr-healthcheck.sh" do
-	source "solr-healthcheck.sh.erb"
+template "/usr/local/bin/solr-env.sh" do
+	source "solr-env.sh.erb"
 	owner "root"
 	group "root"
 	mode "0755"
 end
 
-template "/usr/local/bin/toggle-solr-healthcheck.sh" do
-	source "toggle-solr-healthcheck.sh.erb"
+cookbook_file "/usr/local/bin/solr-healthcheck.sh" do
+	source "solr-healthcheck.sh"
 	owner "root"
 	group "root"
 	mode "0755"
 end
 
-template "/usr/local/bin/pick-solr-master.sh" do
-	source "pick-solr-master.sh.erb"
+cookbook_file "/usr/local/bin/toggle-solr-healthcheck.sh" do
+	source "toggle-solr-healthcheck.sh"
 	owner "root"
 	group "root"
 	mode "0755"
 end
 
-template "/usr/local/bin/solr-sync.sh" do
-	source "solr-sync.sh.erb"
+cookbook_file "/usr/local/bin/pick-solr-master.sh" do
+	source "pick-solr-master.sh"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
+cookbook_file "/usr/local/bin/solr-sync.sh" do
+	source "solr-sync.sh"
 	owner "root"
 	group "root"
 	mode "0755"

--- a/templates/default/solr-env.sh.erb
+++ b/templates/default/solr-env.sh.erb
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+opsworks_hostname="<%= node['datashades']['hostname'] %>"
+BUCKET="<%= node['datashades']['log_bucket'] %>"
+CORE_NAME="<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>"
+HEARTBEAT_FILE="/data/solr-healthcheck_$opsworks_hostname"
+# If present, this file marks a server as "just started, may not be updated, don't use yet"
+STARTUP_FILE="$HEARTBEAT_FILE.start"
+
+EXTRA_DISK="/mnt/local_data"
+LOCAL_DIR="$EXTRA_DISK/solr_backup"
+DATA_DIR="$EXTRA_DISK/solr_data/data/$CORE_NAME/data"
+SYNC_DIR="/data/solr/data/$CORE_NAME/data"
+HOST="http://localhost:8983/solr"
+PING_URL="$HOST/$CORE_NAME/admin/ping"
+LUCENE_JAR=$(ls /opt/solr/server/solr-webapp/webapp/WEB-INF/lib/lucene-core-*.jar | tail -1)
+LUCENE_CHECK="java -cp $LUCENE_JAR -ea:org.apache.lucene... org.apache.lucene.index.CheckIndex"


### PR DESCRIPTION
- Replace unrecoverable indexes offline instead of attempting online
- Run an integrity check on master index exports before pushing them to backups
- Refactor to reduce the number of files that need cookbook interpolation
- Expand swap size for batch servers so they hopefully don't crash during deployments.