### PR TITLE
[QOL-8466] add error checking to app checkout

### DIFF
--- a/resources/pip_install_app.rb
+++ b/resources/pip_install_app.rb
@@ -85,16 +85,15 @@ action :create do
         cwd install_dir
         code <<-EOS
             # retrieve latest branch metadata
-            git fetch origin '#{version}'
-            # drop unversioned files
-            git clean -f
+            git fetch origin '#{version}' || exit 1
             # make versioned files pristine
+            git clean -f
             git reset --hard
-            git checkout '#{version}'
+            find . -name '*.pyc' -delete
+            # move to target revision
+            git checkout '#{version}' || exit 1
             # get latest changes if we're checking out a branch, otherwise it doesn't matter
             git pull
-            # drop compiled files from previous branch
-            find . -name '*.pyc' -delete
             # regenerate metadata
             #{new_resource.virtualenv_dir}/bin/python setup.py develop
         EOS


### PR DESCRIPTION
- Exit early if key steps fail, like fetching the revision from the remote, or actually checking it out. Continue if minor steps fail, like 'git pull' failing when we're on a tag instead of a branch.
- Move cleanup steps into one place.