### PR TITLE
[QOL-8258] oops fix archival shell script

### DIFF
--- a/recipes/ckanbatch-deploy.rb
+++ b/recipes/ckanbatch-deploy.rb
@@ -80,7 +80,7 @@ cookbook_file "/usr/local/bin/archive-resource-revisions.sql" do
 end
 
 cookbook_file "/usr/local/bin/archive-resource-revisions.sh" do
-    source "archive-resource-revisions.sql"
+    source "archive-resource-revisions.sh"
     owner "root"
     group "root"
     mode "0755"


### PR DESCRIPTION
Archival script is populated from the wrong file, making it non-functional.