### PR TITLE
[QOL-8500] extra patching just in case

### DIFF
--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -83,8 +83,8 @@ unless ::File.identical?(installed_solr_version, "/opt/solr")
     end
 end
 
-log4j_version = '2.17.0'
-for jar_type in ['api', 'core', 'slf4j-impl'] do
+log4j_version = '2.17.1'
+for jar_type in ['1.2-api', 'api', 'core', 'slf4j-impl'] do
     log4j_artefact = "log4j-#{jar_type}"
     bash "Patch #{log4j_artefact} to version #{log4j_version}" do
         cwd "/opt/solr/server/lib/ext"


### PR DESCRIPTION
- update Log4J to 2.17.1 although we don't use the vulnerable JDBCAppender
- update the Log4J 1.x bridge although it's probably not vulnerable to anything by itself