### PR TITLE
QOL-8406 improve Solr health checks

### DIFF
--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -7,64 +7,8 @@ set +o pipefail
 
 MAX_AGE=120
 
-LOG_FILE="/var/log/solr/solr_${CORE_NAME}_health-check.log"
-BACKUP_DIR="/tmp/snapshot.health_check"
-
-fix_index () {
-  # Attempt to fix a corrupted Lucene index.
-  # This will drop the server out of the pool,
-  # as the Lucene check can only run offline.
-  rm $HEARTBEAT_FILE
-  sudo service solr stop
-  # extract the index location from 'index.properties' if it exists,
-  # otherwise default to 'index'
-  INDEX_DIR=$(grep 'index=' "$DATA_DIR/index.properties" |awk -F= '{print $2}')
-  if [ "$INDEX_DIR" = "" ]; then
-    INDEX_DIR=index
-  fi
-  INDEX_DIR="$DATA_DIR/$INDEX_DIR"
-  # Attempt to exorcise index corruption.
-  # If even that fails, move the whole index aside for later forensics
-  # and copy a fresh index from the EFS sync.
-  if ! (sudo -u solr sh -c "$LUCENE_CHECK $INDEX_DIR >> $LOG_FILE"); then
-    # Lucene returns an error code if the index was bad,
-    # even if it was successfully exorcised,
-    # so check again to determine whether we actually succeeded.
-    sudo -u solr sh -c "(echo 'Index failed check, attempting to fix'; \
-        $LUCENE_CHECK -exorcise $INDEX_DIR; $LUCENE_CHECK $INDEX_DIR || \
-            (echo 'Index is unrecoverable, copy from backup'; \
-            mv $INDEX_DIR $INDEX_DIR.bad.`date +'%s'` && \
-            rm $DATA_DIR/index.properties && \
-            rsync -a --delete $SYNC_DIR/index/ $DATA_DIR/index) \
-        ) >> $LOG_FILE"
-  fi
-  sudo service solr start
-  touch $HEARTBEAT_FILE
-}
-
 is_ping_healthy () {
-  (curl -I "$PING_URL" 2>/dev/null |grep '200 OK' > /dev/null) || return 1
-}
-
-is_index_healthy () {
-  curl "$HOST/$CORE_NAME/replication?command=backup&location=/tmp&name=health_check" 2>/dev/null \
-    |grep '"status": *"OK"' > /dev/null
-  IS_HEALTHY=$?
-  if [ "$IS_HEALTHY" = "0" ]; then
-    sudo -u solr sh -c "$LUCENE_CHECK $BACKUP_DIR >> $LOG_FILE"
-    IS_HEALTHY=$?
-  fi
-  rm -rf "$BACKUP_DIR"
-  return $IS_HEALTHY
-}
-
-is_healthy () {
-  if ! (is_ping_healthy && is_index_healthy); then
-    fix_index
-    # even if fix_index worked, don't become master yet,
-    # because we might have cleared the index and need to resync.
-    return 1
-  fi
+  (curl -I --connect-timeout 5 "$PING_URL" 2>/dev/null |grep '200 OK' > /dev/null) || return 1
 }
 
 # Only update heartbeat if it is present.

--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -74,7 +74,7 @@ if ! [ -e "$HEARTBEAT_FILE" ]; then
 fi
 
 CURRENT_TIME=$(date +%s)
-is_healthy || exit 1
+is_ping_healthy || exit 1
 PREVIOUS_HEALTH_TIME=$(cat $HEARTBEAT_FILE | tr -d '[:space:]')
 echo $CURRENT_TIME > "$HEARTBEAT_FILE"
 if [ "$PREVIOUS_HEALTH_TIME" = "" ]; then

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -31,7 +31,7 @@ function wait_for_replication_success () {
 }
 
 # we can't perform any replication operations if Solr is stopped
-if ! (curl -I --connect-timeout 5 "$HOST/$CORE_NAME/admin/ping" 2>/dev/null |grep '200 OK' > /dev/null); then
+if ! (curl -I --connect-timeout 5 "$PING_URL" 2>/dev/null |grep '200 OK' > /dev/null); then
   set_dns_primary false
   exit 0
 fi

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -17,6 +17,19 @@ function set_dns_primary () {
   updatedns &
 }
 
+function wait_for_replication_success () {
+  # wait up to 20 seconds for backup to complete, should only take a second or two
+  BACKUP_STATUS=unknown
+  for i in {1..20}; do
+    if [ "$BACKUP_STATUS" = "unknown" ]; then
+      DETAILS=$(curl "$HOST/$CORE_NAME/replication?command=details")
+      echo "$DETAILS" |grep 'status[^a-zA-Z]*success' && return 0
+      echo "$DETAILS" |grep 'exception.*snapshot' && return 1
+      sleep 1
+    fi
+  done
+}
+
 # we can't perform any replication operations if Solr is stopped
 if ! (curl -I --connect-timeout 5 "$HOST/$CORE_NAME/admin/ping" 2>/dev/null |grep '200 OK' > /dev/null); then
   set_dns_primary false
@@ -25,14 +38,19 @@ fi
 sudo mkdir -p "$LOCAL_DIR"
 sudo chown solr "$LOCAL_DIR"
 if (/usr/local/bin/pick-solr-master.sh); then
+  # point traffic to this instance
   set_dns_primary true
-  curl "$HOST/$CORE_NAME/replication?command=backup&location=$LOCAL_DIR&name=$BACKUP_NAME"
-  sleep 5
+
+  # export a snapshot of the index and verify its integrity,
+  # then copy to EFS so secondary servers can read it
+  curl "$HOST/$CORE_NAME/replication?command=backup&location=$LOCAL_DIR&name=$BACKUP_NAME" | grep 'status[^a-zA-Z]*OK' || exit 1
+  wait_for_replication_success || exit 1
   sudo -u solr sh -c "$LUCENE_CHECK $LOCAL_SNAPSHOT && rsync -a --delete '$LOCAL_SNAPSHOT' '$SYNC_SNAPSHOT'" || exit 1
+
+  # clean up - remove old snapshots, hourly backup to S3
   for old_snapshot in $(ls -d $SYNC_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME"); do
     sudo -u solr rm -r "$old_snapshot"
   done
-  # sweep backups to S3 every hour
   if [ "$MINUTE" = "00" ]; then
     cd "$LOCAL_DIR"
     tar --force-local -czf "$SNAPSHOT_NAME.tgz" "$SNAPSHOT_NAME"
@@ -40,6 +58,7 @@ if (/usr/local/bin/pick-solr-master.sh); then
     sudo -u solr rm -r snapshot.$CORE_NAME-*
   fi
 else
+  # make traffic come to this instance only as a backup option
   set_dns_primary false
   # Give the master time to update the sync copy; run halfway between exports
   sleep 30

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 . `dirname $0`/solr-env.sh
 
 BACKUP_NAME="$CORE_NAME-$(date +'%Y-%m-%dT%H:%M')"

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -41,8 +41,8 @@ if (/usr/local/bin/pick-solr-master.sh); then
   fi
 else
   set_dns_primary false
-  # Give the master time to update the sync copy
-  sleep 10
+  # Give the master time to update the sync copy; run halfway between exports
+  sleep 30
   if [ -d "$SYNC_SNAPSHOT" ]; then
     sudo -u solr rm -r $LOCAL_DIR/snapshot.$CORE_NAME-*
     sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT" "$LOCAL_SNAPSHOT" || exit 1

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -28,6 +28,9 @@ function wait_for_replication_success () {
       sleep 1
     fi
   done
+  if [ "$BACKUP_STATUS" = "unknown" ]; then
+    return 1
+  fi
 }
 
 function export_snapshot () {

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -85,7 +85,7 @@ end
 
 # synchronise Solr cores via EFS
 file "/etc/cron.d/solr-sync" do
-	content "* * * * * root /usr/local/bin/solr-sync.sh > /dev/null 2>&1\n"
+	content "* * * * * root /usr/local/bin/solr-sync.sh >> /var/log/solr/solr-sync.cron.log 2>&1\n"
 	mode "0644"
 end
 

--- a/recipes/solr-deploycore.rb
+++ b/recipes/solr-deploycore.rb
@@ -61,3 +61,6 @@ execute 'Unzip Core Config' do
 	command "unzip -u -q -o #{Chef::Config[:file_cache_path]}/solr_core_config.zip -d #{solr_core_dir}"
 end
 
+service "solr" do
+	action [:start]
+end


### PR DESCRIPTION
- Drop extra index integrity checks as they are causing collisions
- Don't manually tamper with index directory as it can race with current transactions
- Space out backup consumption more from backup export