### PR TITLE
[QOL-8638] make Solr master election more robust

### DIFF
--- a/files/default/pick-solr-master.sh
+++ b/files/default/pick-solr-master.sh
@@ -21,22 +21,22 @@ function is_healthy() {
   return $(expr $AGE '>' $MAX_AGE)
 }
 
-layer_prefix=$(echo "$opsworks_hostname" | tr -d '[0-9]')
 NOW=$(date +'%s')
 MAX_AGE=120
-for i in {9..1}; do
-  SERVER_NAME="$layer_prefix$i"
-  if is_healthy "/data/solr-healthcheck_$SERVER_NAME"; then
-    SELECTED_SERVER="$SERVER_NAME"
+
+HEALTH_CHECK_PREFIX=/data/solr-healthcheck_
+HEALTH_CHECK_FILES=$(ls -r ${HEALTH_CHECK_PREFIX}* || echo '')
+for health_check_file in $HEALTH_CHECK_FILES; do
+  if is_healthy "$health_check_file"; then
+    SELECTED_SERVER="$health_check_file"
   fi
 done
 # if we have no master, try grabbing one that's only passed a single health check
 if [ "$SELECTED_SERVER" = "" ]; then
-  for i in {9..1}; do
-    SERVER_NAME="$layer_prefix$i"
-    if is_healthy "/data/solr-healthcheck_$SERVER_NAME" true; then
-      SELECTED_SERVER="$SERVER_NAME"
+  for health_check_file in $HEALTH_CHECK_FILES; do
+    if is_healthy "$health_check_file" true; then
+      SELECTED_SERVER="$health_check_file"
     fi
   done
 fi
-exit $([ "$SELECTED_SERVER" = "$opsworks_hostname" ])
+exit $([ "$SELECTED_SERVER" = "${HEALTH_CHECK_PREFIX}$opsworks_hostname" ])


### PR DESCRIPTION
- Detect any Solr health checks present, regardless of hostname pattern, and up to any maximum number.