### PR TITLE
[QOL-8576] improve logic for picking job master

### DIFF
--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -53,12 +53,6 @@ template "/usr/local/bin/ckan-monitor-job-queue.sh" do
 end
 
 file "/etc/cron.d/ckan-worker" do
-    content "*/5 * * * * ckan /usr/local/bin/pick-job-server.sh && /usr/local/bin/ckan-monitor-job-queue.sh >/dev/null 2>&1\n"
+    content "*/5 * * * * root /usr/local/bin/pick-job-server.sh && /usr/local/bin/ckan-monitor-job-queue.sh >/dev/null 2>&1\n"
     mode '0644'
-end
-
-# Make any other instances aware of us
-#
-file "/data/#{node['datashades']['hostname']}" do
-    content "#{node['datashades']['instid']}"
 end

--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -56,3 +56,7 @@ file "/etc/cron.d/ckan-worker" do
     content "*/5 * * * * root /usr/local/bin/pick-job-server.sh && /usr/local/bin/ckan-monitor-job-queue.sh >/dev/null 2>&1\n"
     mode '0644'
 end
+
+# Make any other instances aware of us
+#
+execute "/usr/local/bin/pick-job-server.sh"

--- a/templates/default/pick-job-server.sh.erb
+++ b/templates/default/pick-job-server.sh.erb
@@ -3,11 +3,31 @@
 # Identify whether the current server is the one that should run cron jobs.
 # This is simply intended to ensure that jobs are run exactly once.
 
+function is_healthy() {
+  HEALTH_FILE=$1
+  if [ ! -e "$HEALTH_FILE" ]; then
+    return 1
+  fi
+  HEALTH_TIME=$(cat $1 | tr -d '[:space:]')
+  if [ "$HEALTH_TIME" = "" ]; then
+    return 1
+  fi
+  AGE=$(expr $NOW - $HEALTH_TIME)
+  return $(expr $AGE '>' $MAX_AGE)
+}
+
+NOW=$(date +'%s')
+MAX_AGE=600
+
 opsworks_hostname="<%= node['datashades']['hostname'] %>"
-layer_prefix=$(echo "$opsworks_hostname" | tr -d '[0-9]')
-for i in {1..9}; do
-  if [ -e "/data/$layer_prefix$i" ]; then
-    JOB_SERVER="$layer_prefix$i"
+HEALTH_CHECK_PREFIX=/data/batch-healthcheck_
+HEARTBEAT_FILE="${HEALTH_CHECK_PREFIX}$opsworks_hostname"
+echo $NOW > "$HEARTBEAT_FILE"
+
+HEALTH_CHECK_FILES=$(ls -r ${HEALTH_CHECK_PREFIX}* || echo '')
+for health_check_file in $HEALTH_CHECK_FILES; do
+  if is_healthy "$health_check_file"; then
+    SELECTED_SERVER="$health_check_file"
   fi
 done
-exit $([ "$JOB_SERVER" = "$opsworks_hostname" ])
+exit $([ "$SELECTED_SERVER" = "${HEARTBEAT_FILE}" ])


### PR DESCRIPTION
- list heartbeat files alphabetically instead of trying to guess the names
- use heartbeat timestamps to determine whether a server is still active