### PR TITLE
QOL-8576 fix batch job to submit queue metrics

### DIFF
--- a/templates/default/ckan-monitor-job-queue.sh.erb
+++ b/templates/default/ckan-monitor-job-queue.sh.erb
@@ -14,7 +14,7 @@ function send_queue_metrics () {
     LOG_FILE="/var/log/ckan/${QUEUE_LOG}.log"
     TEMP_FILE="/tmp/${QUEUE_LOG}.log"
     echo "CKAN job $1 queue(s) at $(date):" >> $LOG_FILE
-    JOB_COUNT=$(/usr/lib/ckan/default/bin/ckan_cli jobs list $QUEUE 2>/dev/null | tee -a $LOG_FILE | tee $TEMP_FILE | wc -l)
+    JOB_COUNT=$(/usr/lib/ckan/default/bin/ckan_cli jobs list $QUEUE 2>/dev/null | grep -v 'There are no pending jobs' | tee -a $LOG_FILE | tee $TEMP_FILE | wc -l)
     echo "Total: $JOB_COUNT job(s)" >> $LOG_FILE
     if [ "$JOB_COUNT" -gt 0 ]; then
         OLDEST_TIME=$(date -u --date $(head -1 $TEMP_FILE | awk '{print $1}') +'%s')

--- a/templates/default/ckan-monitor-job-queue.sh.erb
+++ b/templates/default/ckan-monitor-job-queue.sh.erb
@@ -14,7 +14,7 @@ function send_queue_metrics () {
     LOG_FILE="/var/log/ckan/${QUEUE_LOG}.log"
     TEMP_FILE="/tmp/${QUEUE_LOG}.log"
     echo "CKAN job $1 queue(s) at $(date):" >> $LOG_FILE
-    JOB_COUNT=$(/usr/lib/ckan/default/bin/ckan_cli jobs list $QUEUE 2>/dev/null | grep -v 'There are no pending jobs' | tee -a $LOG_FILE | tee $TEMP_FILE | wc -l)
+    JOB_COUNT=$(/usr/lib/ckan/default/bin/ckan_cli jobs list $QUEUE 2>/dev/null | tee -a $LOG_FILE | grep -v 'There are no pending jobs' | tee $TEMP_FILE | wc -l)
     echo "Total: $JOB_COUNT job(s)" >> $LOG_FILE
     if [ "$JOB_COUNT" -gt 0 ]; then
         OLDEST_TIME=$(date -u --date $(head -1 $TEMP_FILE | awk '{print $1}') +'%s')


### PR DESCRIPTION
CKAN 2.9 prints a message when the queue is empty, which the script wasn't expecting, and it ends up being interpreted as a timestamp. This change will cause the message to be ignored.