### PR TITLE
Develop to master

### DIFF
--- a/templates/default/ckan-monitor-job-queue.sh.erb
+++ b/templates/default/ckan-monitor-job-queue.sh.erb
@@ -14,7 +14,7 @@ function send_queue_metrics () {
     LOG_FILE="/var/log/ckan/${QUEUE_LOG}.log"
     TEMP_FILE="/tmp/${QUEUE_LOG}.log"
     echo "CKAN job $1 queue(s) at $(date):" >> $LOG_FILE
-    JOB_COUNT=$(/usr/lib/ckan/default/bin/ckan_cli jobs list $QUEUE 2>/dev/null | tee -a $LOG_FILE | tee $TEMP_FILE | wc -l)
+    JOB_COUNT=$(/usr/lib/ckan/default/bin/ckan_cli jobs list $QUEUE 2>/dev/null | tee -a $LOG_FILE | grep -v 'There are no pending jobs' | tee $TEMP_FILE | wc -l)
     echo "Total: $JOB_COUNT job(s)" >> $LOG_FILE
     if [ "$JOB_COUNT" -gt 0 ]; then
         OLDEST_TIME=$(date -u --date $(head -1 $TEMP_FILE | awk '{print $1}') +'%s')

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -83,7 +83,7 @@ ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/allowed_functions.txt
 ## Site Settings
 
 ckan.site_url = https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>
-ckan.user_reset_landing_page = user/reset
+ckan.user_reset_landing_page = /user/reset
 ckan.hide_version = True
 
 ## QGOV Settings


### PR DESCRIPTION
Use full path for password reset landing page, so we don't go to /user/user/reset by mistake.