### PR TITLE
[DC-32168] add cron job to purge old Beaker session cache files

### DIFF
--- a/recipes/httpd-configure.rb
+++ b/recipes/httpd-configure.rb
@@ -36,6 +36,20 @@ file "/etc/cron.daily/archive-apache-logs-to-s3" do
 	mode "0755"
 end
 
+template '/usr/local/bin/clean-beaker-cache.sh' do
+	source "clean-beaker-cache.sh.erb"
+	mode "0755"
+	owner "root"
+	group "root"
+end
+
+file "/etc/cron.hourly/clean-beaker-cache" do
+	content "/usr/local/bin/clean-beaker-cache.sh >/dev/null 2>&1\n"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
 # Re-enable and start in case it was stopped by previous recipe versions and reload if already started
 service 'httpd' do
 	supports :restart => true, :reload => true, :status => true

--- a/templates/default/clean-beaker-cache.sh.erb
+++ b/templates/default/clean-beaker-cache.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Remove obsolete Beaker session files.
+# See https://beaker.readthedocs.io/en/latest/sessions.html#removing-expired-old-sessions
+
+SESSION_CACHE_DIR=/tmp/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/sessions
+EXPIRY_DAYS=$1
+if [ "$EXPIRY_DAYS" = "" ]; then
+  EXPIRY_DAYS=3
+fi
+
+find $SESSION_CACHE_DIR -type f -mtime +"$EXPIRY_DAYS" -execdir rm '{}' ';'


### PR DESCRIPTION
- Beaker does not remove these by itself, causing the disk to fill with hundreds of thousands of small files.
They don't take up much space, but they endanger the half-million inode limit.