### PR TITLE
[DC-32168] use 'find -exec' instead of '-execdir'

### DIFF
--- a/recipes/ckanweb-configure.rb
+++ b/recipes/ckanweb-configure.rb
@@ -25,5 +25,5 @@ include_recipe "datashades::httpd-configure"
 include_recipe "datashades::nginx-configure"
 
 service 'php-fpm-5.5' do
-	action [:restart]
+    action [:restart]
 end

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -48,8 +48,8 @@ beaker.session.secure = true
 #60 min session
 beaker.session.timeout = 3600
 beaker.session.save_accessed_time = true
-#beaker.session.type = redis
-#beaker.session.url = <%= node['datashades']['redis']['hostname'] %>:<%= node['datashades']['redis']['port'] %>
+beaker.session.type = ext:redis
+beaker.session.url = redis://<%= node['datashades']['redis']['hostname'] %>:<%= node['datashades']['redis']['port'] %>/0
 beaker.session.cookie_expires = true
 # Your domain should show here.
 beaker.session.cookie_domain = <%= @app_url %>

--- a/templates/default/clean-beaker-cache.sh.erb
+++ b/templates/default/clean-beaker-cache.sh.erb
@@ -9,4 +9,4 @@ if [ "$EXPIRY_DAYS" = "" ]; then
   EXPIRY_DAYS=3
 fi
 
-find $SESSION_CACHE_DIR -type f -mtime +"$EXPIRY_DAYS" -execdir rm '{}' ';'
+find $SESSION_CACHE_DIR -type f -mtime +"$EXPIRY_DAYS" -exec rm '{}' ';'


### PR DESCRIPTION
- 'execdir' is safer on untrusted inputs, but opens a file descriptor each time, which crashes when operating on large numbers of files. In this case, we trust the inputs.