### PR TITLE
QOL-9055 prepare for Amazon Linux 2

### DIFF
--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -22,7 +22,8 @@
 #
 
 default['datashades']['ckan_web']['endpoint'] = '/'
-default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'postgresql94-devel', 'postgresql94', 'python27-devel', 'python27-pip', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'gcc', 'gcc-c++', 'make', 'xalan-j2', 'unzip', 'policycoreutils-python', 'mod24_wsgi-python27', 'supervisor', 'squid']
+default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'gcc', 'gcc-c++', 'make', 'xalan-j2', 'unzip', 'policycoreutils-python', 'supervisor', 'squid']
+default['datashades']['ckan_web']['alternative_packages'] = ['postgresql94', 'postgresql94-devel', 'postgresql', 'postgresql-devel', 'python27-devel', 'python3-devel', 'python27-pip', 'python3-pip', 'libxslt', 'libxslt-devel', 'mod24_wsgi-python27', 'mod_wsgi']
 
 default['datashades']['ckan_web']['dbuser'] = 'ckan_default'
 default['datashades']['ckan_web']['dbname'] = 'ckan_default'
@@ -57,7 +58,7 @@ default['datashades']['ckan_web']['google']['analytics_id'] = 'UA-7276966-12'
 default['datashades']['ckan_web']['wsgi']['processes'] = '1'
 default['datashades']['ckan_web']['wsgi']['threads'] = '15'
 
-default['datashades']['ckan_ext']['packages'] = ['geos-devel.x86_64', 'npm']
+default['datashades']['ckan_ext']['packages'] = ['geos-devel.x86_64']
 
 default['datashades']['postgres']['password'] = ""
 

--- a/files/default/fix-dns.sh
+++ b/files/default/fix-dns.sh
@@ -2,7 +2,7 @@
 
 dns_ok () {
   # Check if DNS is working
-  /usr/bin/dig example.com +time=1 +tries=1 >/dev/null 2>&1 || return 1
+  dig example.com +time=1 +tries=1 >/dev/null 2>&1 || return 1
 }
 
 dns_ok && exit 0

--- a/recipes/ckan-deploy.rb
+++ b/recipes/ckan-deploy.rb
@@ -70,6 +70,10 @@ end
 # Install selected revision of CKAN core
 #
 
+execute "Pin setuptools version" do
+	command "#{virtualenv_dir}/bin/pip install setuptools==44.1.0"
+end
+
 datashades_pip_install_app "ckan" do
 	type app['app_source']['type']
 	revision app['app_source']['revision']

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -115,16 +115,9 @@ directory real_virtualenv_dir do
 	recursive true
 end
 
-bash "Fix VirtualEnv lib issue" do
-	user "ckan"
-	group "ckan"
-	cwd "#{virtualenv_dir}"
-	code <<-EOS
-		mv -f lib/python2.7/site-packages lib64/python2.7/
-		rm -rf lib
-		ln -sf lib64 lib
-	EOS
-	not_if { ::File.symlink? "#{virtualenv_dir}/lib" }
+datashades_move_and_link "#{virtualenv_dir}/lib" do
+	target "#{virtualenv_dir}/lib64"
+	owner 'ckan'
 end
 
 #

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -39,7 +39,8 @@ end
 #
 group "ckan" do
 	action :create
-	gid '1000'
+	gid '2000'
+	not_if { ::File.directory? "/home/ckan" }
 end
 
 # Create CKAN User
@@ -49,8 +50,9 @@ user "ckan" do
 	home "/home/ckan"
 	shell "/sbin/nologin"
 	action :create
-	uid '1000'
+	uid '2000'
 	group 'ckan'
+	not_if { ::File.directory? "/home/ckan" }
 end
 
 # Explicitly set permissions on ckan directory so it's readable by Apache

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -24,6 +24,17 @@ node['datashades']['ckan_web']['packages'].each do |p|
 	package p
 end
 
+# Install packages that have different names on different systems
+node['datashades']['ckan_web']['alternative_packages'].each do |p|
+	bash "Install #{p} if available" do
+		code <<-EOS
+			if (yum info "#{p}"); then
+				yum install -y "#{p}"
+			fi
+		EOS
+	end
+end
+
 # Create CKAN Group
 #
 group "ckan" do

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -99,7 +99,8 @@ end
 
 bash "Create CKAN Default Virtual Environment" do
 	code <<-EOS
-		/usr/bin/virtualenv --no-site-packages #{real_virtualenv_dir}
+		PATH="$PATH:/usr/local/bin"
+		virtualenv #{real_virtualenv_dir}
 		chown -R ckan:ckan #{real_virtualenv_dir}
 	EOS
 	not_if { ::File.directory? "#{real_virtualenv_dir}/bin" }

--- a/recipes/ckanbatch-setup.rb
+++ b/recipes/ckanbatch-setup.rb
@@ -40,6 +40,7 @@ bash "Enable Supervisor file inclusions" do
 	EOS
 end
 
+# Configure either initd or systemd
 if ::File.exist? "/etc/init.d/supervisord" then
 	# Managed processes sometimes don't shut down properly on daemon stop,
 	# leaving them 'orphaned' and resulting in duplicates.

--- a/recipes/ckanbatch-setup.rb
+++ b/recipes/ckanbatch-setup.rb
@@ -40,11 +40,35 @@ bash "Enable Supervisor file inclusions" do
 	EOS
 end
 
-# Managed processes sometimes don't shut down properly on daemon stop,
-# leaving them 'orphaned' and resulting in duplicates.
-# Work around by issuing a stop command to the children first.
-execute "Stop children on supervisord stop" do
-	command <<-'SED'.strip + " /etc/init.d/supervisord"
-		sed -i 's/^\(\s*\)\(killproc\)/\1timeout 10s supervisorctl stop all || echo "WARNING: Unable to stop managed process(es) - check for orphans"; \2/'
-	SED
+if ::File.exist? "/etc/init.d/supervisord" then
+	# Managed processes sometimes don't shut down properly on daemon stop,
+	# leaving them 'orphaned' and resulting in duplicates.
+	# Work around by issuing a stop command to the children first.
+	execute "Stop children on supervisord stop" do
+		command <<-'SED'.strip + " /etc/init.d/supervisord"
+			sed -i 's/^\(\s*\)\(killproc\)/\1timeout 10s supervisorctl stop all || echo "WARNING: Unable to stop managed process(es) - check for orphans"; \2/'
+		SED
+	end
+else
+	systemd_unit "supervisord.service" do
+		content({
+			Unit: {
+				Description: 'Supervisor process control system for UNIX',
+				Documentation: 'http://supervisord.org',
+				After: 'network.target'
+			},
+			Service: {
+				ExecStart: '/usr/bin/supervisord -n -c /etc/supervisord.conf',
+				ExecStop: 'timeout 10s /usr/bin/supervisorctl stop all || echo "WARNING: Unable to stop managed process(es) - check for orphans"; /usr/bin/supervisorctl $OPTIONS shutdown',
+				ExecReload: '/usr/bin/supervisorctl $OPTIONS reload',
+				KillMode: 'process',
+				Restart: 'on-failure',
+				RestartSec: '20s'
+			},
+			Install: {
+				WantedBy: 'multi-user.target'
+			}
+		})
+		action [:create, :enable]
+	end
 end

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -387,8 +387,8 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 		# See https://github.com/dateutil/dateutil/issues/402
 		execute "Patch date parser format" do
 			user "#{account_name}"
-			command <<-'SED'.strip + " #{virtualenv_dir}/lib/python2.7/site-packages/messytables/types.py"
-				sed -i "s/^\(\s*\)return parser[.]parse(value)/\1for fmt in ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S%z', '%Y-%m-%d %H:%M:%S%z', '%Y-%m-%dT%H:%M:%S.%f%z', '%Y-%m-%d %H:%M:%S.%f%z']:\n\1    try:\n\1        return datetime.datetime.strptime(value, fmt)\n\1    except ValueError:\n\1        pass\n\1return parser.parse(value, dayfirst=True)/"
+			command <<-'SED'.strip + " #{virtualenv_dir}/lib/*/site-packages/messytables/types.py"
+				sed -i "s/^\(\s*\)return parser[.]parse(value)/\1try:\n\1    return parser.isoparse(value)\n\1except ValueError:\n\1    return parser.parse(value, dayfirst=True)/"
 			SED
 		end
 	end

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -108,6 +108,10 @@ node['datashades']['ckan_ext']['packages'].each do |p|
 	package p
 end
 
+execute "Install NodeJS 10.x" do
+	command "curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -; yum -y install nodejs"
+end
+
 # Do the actual extension installation using pip
 #
 harvester_data_qld_geoscience_present = false

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -108,8 +108,14 @@ node['datashades']['ckan_ext']['packages'].each do |p|
 	package p
 end
 
-execute "Install NodeJS 10.x" do
-	command "curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -; yum -y install nodejs"
+bash "Install NPM and NodeJS" do
+	code <<-EOS
+		if ! (yum install -y npm); then
+			# failed to install from standard repo, try a manual setup
+			curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+			yum -y install nodejs
+		fi
+	EOS
 end
 
 # Do the actual extension installation using pip

--- a/recipes/datapusher-deploy.rb
+++ b/recipes/datapusher-deploy.rb
@@ -29,30 +29,12 @@ service_name = "datapusher"
 
 app = search("aws_opsworks_app", "shortname:#{node['datashades']['app_id']}-#{node['datashades']['version']}-#{service_name}*").first
 virtualenv_dir = "/usr/lib/ckan/#{service_name}"
-pip = "#{virtualenv_dir}/bin/pip --cache-dir=/tmp/"
 install_dir = "#{virtualenv_dir}/src/#{service_name}"
 
-execute "Install app from source" do
-	user "#{service_name}"
-	group "#{service_name}"
-	command "#{pip} install -e 'git+#{app['app_source']['url']}@#{app['app_source']['revision']}#egg=#{service_name}'"
-	not_if { ::File.directory? "#{install_dir}" }
-end
-
-apprevision = app['app_source']['revision']
-execute "Check out selected revision" do
-	user "#{service_name}"
-	group "#{service_name}"
-	cwd "#{install_dir}"
-	# pull if we're checking out a branch, otherwise it doesn't matter
-	command "git fetch; git checkout '#{apprevision}'; git pull || true"
-	not_if apprevision.nil?
-end
-
-execute "Install Python dependencies" do
-	user "#{service_name}"
-	group "#{service_name}"
-	command "#{pip} install -r '#{install_dir}/requirements.txt'"
+datashades_pip_install_app "datapusher" do
+	type app['app_source']['type']
+	revision app['app_source']['revision']
+	url app['app_source']['url']
 end
 
 # The dateparser library defaults to month-first but is configurable.

--- a/recipes/datapusher-deploy.rb
+++ b/recipes/datapusher-deploy.rb
@@ -60,8 +60,8 @@ end
 # See https://github.com/dateutil/dateutil/issues/402
 execute "Patch date parser format" do
 	user "#{service_name}"
-	command <<-'SED'.strip + " #{virtualenv_dir}/lib/python2.7/site-packages/messytables/types.py"
-		sed -i "s/^\(\s*\)return parser[.]parse(value)/\1for fmt in ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%S.%f']:\n\1    try:\n\1        return datetime.datetime.strptime(value, fmt)\n\1    except ValueError:\n\1        pass\n\1return parser.parse(value, dayfirst=True)/"
+	command <<-'SED'.strip + " #{virtualenv_dir}/lib/*/site-packages/messytables/types.py"
+		sed -i "s/^\(\s*\)return parser[.]parse(value)/\1try:\n\1    return parser.isoparse(value)\n\1except ValueError:\n\1    return parser.parse(value, dayfirst=True)/"
 	SED
 end
 

--- a/recipes/datapusher-setup.rb
+++ b/recipes/datapusher-setup.rb
@@ -64,7 +64,8 @@ end
 bash "Create Virtual Environment" do
 	user "root"
 	code <<-EOS
-		/usr/bin/virtualenv --no-site-packages "#{virtualenv_dir}"
+		PATH="$PATH:/usr/local/bin"
+		virtualenv "#{virtualenv_dir}"
 		chown -R #{service_name}:#{service_name} "#{virtualenv_dir}"
 	EOS
 	not_if { ::File.directory? "#{virtualenv_dir}/bin" }

--- a/recipes/datapusher-setup.rb
+++ b/recipes/datapusher-setup.rb
@@ -71,16 +71,9 @@ bash "Create Virtual Environment" do
 	not_if { ::File.directory? "#{virtualenv_dir}/bin" }
 end
 
-bash "Fix VirtualEnv lib issue" do
-	user "#{service_name}"
-	group "#{service_name}"
-	cwd "#{virtualenv_dir}"
-	code <<-EOS
-	mv -f lib/python2.7/site-packages lib64/python2.7/
-	rm -rf lib
-	ln -sf lib64 lib
-	EOS
-	not_if { ::File.symlink? "#{virtualenv_dir}/lib" }
+datashades_move_and_link "#{virtualenv_dir}/lib" do
+	target "#{virtualenv_dir}/lib64"
+	owner 'ckan'
 end
 
 #

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,10 +80,11 @@ end
 
 bash "Link 'pip' if not present" do
     code <<-EOS
-        which pip && exit 0
-        PIP3=`which pip3`
-        if [ "$PIP3" != "" ]; then
-            ln -s "$PIP3" /usr/bin/pip
+        if ! (which pip); then
+            PIP3=`which pip3`
+            if [ "$PIP3" != "" ]; then
+                ln -s "$PIP3" /usr/bin/pip
+            fi
         fi
     EOS
 end

--- a/resources/move_and_link.rb
+++ b/resources/move_and_link.rb
@@ -2,8 +2,8 @@
 # Moves a directory to a new location and leaves a symlink behind.
 # If the new location already exists, the contents will be merged,
 # with the moved files taking priority.
-# If the old location does not exist, the link will still be created,
-# but will point to nothing.
+# If the old and new locations do not exist, the link will be created at
+# the old location, but will point to nothing.
 #
 # Copyright 2021, Queensland Government
 #

--- a/resources/move_and_link.rb
+++ b/resources/move_and_link.rb
@@ -1,7 +1,9 @@
 #
 # Moves a directory to a new location and leaves a symlink behind.
-# If the directory does not exist, the link will still be created,
-# but will be broken until another recipe creates the target directory.
+# If the new location already exists, the contents will be merged,
+# with the moved files taking priority.
+# If the old location does not exist, the link will still be created,
+# but will point to nothing.
 #
 # Copyright 2021, Queensland Government
 #

--- a/resources/pip_install_app.rb
+++ b/resources/pip_install_app.rb
@@ -105,7 +105,7 @@ action :create do
         group new_resource.account_name
         cwd install_dir
         code <<-EOS
-            PYTHON_MAJOR_VERSION=$(python -c "import sys; print(sys.version_info.major)")
+            PYTHON_MAJOR_VERSION=$(#{virtualenv_dir}/bin/python -c "import sys; print(sys.version_info.major)")
             PY2_REQUIREMENTS_FILE=requirements-py2.txt
             if [ "$PYTHON_MAJOR_VERSION" = "2" ] && [ -f $PY2_REQUIREMENTS_FILE ]; then
                 REQUIREMENTS_FILE=$PY2_REQUIREMENTS_FILE

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -126,7 +126,6 @@ solr_url = http://<%= node['datashades']['app_id'] %>solr.<%= node['datashades']
 #       Add ``resource_proxy`` to enable resorce proxying and get around the
 #       same origin policy
 ckan.plugins = stats resource_proxy text_preview recline_preview text_view webpage_view recline_grid_view image_view recline_view recline_graph_view recline_map_view
-ckan.preview.xml_formats = xml red rdf+xml owl+xml atom rss xsd
 
 trak.display_pageviews = true
 
@@ -167,7 +166,7 @@ ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain a
 
 ckan.views.default_views = text_view image_view recline_view
 ckan.preview.json_formats = json
-ckan.preview.xml_formats = xml rdf rdf+xml owl+xml atom rss
+ckan.preview.xml_formats = xml red rdf rdf+xml owl+xml atom rss xsd
 ckan.preview.text_formats = text plain text/plain
 
 ## resource_proxy


### PR DESCRIPTION
- Split package installation so we can install different versions according to what is available, eg 'postgresql94' vs just 'postgresql'.
- Install NPM manually if there isn't a suitable repo version.
- Combine duplicate CKAN config entries, which are now rejected by CKAN.
- Use a different CKAN group ID since the old one clashes with the new 'ec2-user' ID. NB Existing accounts will be unchanged.
- Handle both Python 2 and Python 3 paths.
- Handle systemd as an alternative to initd.
- Drop deprecated 'virtualenv' flag that is no longer supported under Python 3.