### PR TITLE
QOL-9055 Prepare for Amazon Linux 2

### DIFF
--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -22,8 +22,14 @@
 #
 
 default['datashades']['ckan_web']['endpoint'] = '/'
-default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'gcc', 'gcc-c++', 'make', 'xalan-j2', 'unzip', 'policycoreutils-python', 'supervisor', 'squid']
-default['datashades']['ckan_web']['alternative_packages'] = ['postgresql94', 'postgresql94-devel', 'postgresql', 'postgresql-devel', 'python27-devel', 'python3-devel', 'python27-pip', 'python3-pip', 'libxslt', 'libxslt-devel', 'mod24_wsgi-python27', 'mod_wsgi']
+default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'libxslt', 'libxslt-devel', 'gcc', 'gcc-c++', 'make', 'xalan-j2', 'unzip', 'policycoreutils-python', 'supervisor', 'squid']
+default['datashades']['ckan_web']['alternative_packages'] = [
+    ['postgresql94', 'postgresql'],
+    ['postgresql94-devel', 'postgresql-devel'],
+    ['python27-devel', 'python3-devel'],
+    ['python27-pip', 'python3-pip'],
+    ['mod24_wsgi-python27', 'mod_wsgi']
+]
 
 default['datashades']['ckan_web']['dbuser'] = 'ckan_default'
 default['datashades']['ckan_web']['dbname'] = 'ckan_default'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default['datashades']['sitename'] = 'ckan'
 
 default['datashades']['backup']['retention'] = '30'
 
-default['datashades']['core']['packages'] = ['yum-cron', 'clamav', 'gcc', 'jq', 'java-1.8.0-openjdk', 'perl-Switch', 'perl-DateTime', 'perl-Sys-Syslog', 'perl-LWP-Protocol-https', 'perl-Digest-SHA.x86_64', 'git', 'telnet']
+default['datashades']['core']['packages'] = ['nfs-utils', 'yum-cron', 'clamav', 'gcc', 'jq', 'java-1.8.0-openjdk', 'perl-Switch', 'perl-DateTime', 'perl-Sys-Syslog', 'perl-LWP-Protocol-https', 'perl-Digest-SHA.x86_64', 'git', 'telnet']
 default['datashades']['core']['unwanted-packages'] = ['java-1.7.0-openjdk']
 
 default['datashades']['jumpbox']['usergroup'] = ''

--- a/attributes/nfs.rb
+++ b/attributes/nfs.rb
@@ -21,6 +21,6 @@
 # limitations under the License.
 #
 
-default['datashades']['nfs']['packages'] = ['nfs-utils', 'nfs-utils-lib']
+default['datashades']['nfs']['packages'] = []
 default['datashades']['nfs']['exports'] = []
 default['datashades']['nfs']['cidr'] = '172.31.0.0/16'

--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -21,7 +21,7 @@
 # limitations under the License.
 #
 
-default['datashades']['nginx']['packages'] = ['nfs-utils', 'nfs-utils-lib', 'nginx', 'perl', 'libaio', 'ghostscript', 'ImageMagick', 'php55', 'php55-fpm', 'php55-opcache', 'php55-pecl-apcu', 'php55-pdo', 'php55-mysqlnd', 'php55-pecl-memcache', 'php55-pecl-memcached', 'php55-mbstring', 'php55-gd', 'php55-mcrypt', 'php55-soap']
+default['datashades']['nginx']['packages'] = ['nginx', 'perl', 'libaio', 'ghostscript', 'ImageMagick']
 default['datashades']['nginx']['ssl'] = false
 default['datashades']['nginx']['maxdl'] = '512M'
 default['datashades']['nginx']['mem_limit'] = '256M'

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -26,10 +26,12 @@ end
 
 # Install packages that have different names on different systems
 node['datashades']['ckan_web']['alternative_packages'].each do |p|
-	bash "Install #{p} if available" do
+	bash "Install one of #{p}" do
 		code <<-EOS
-			if (yum info "#{p}"); then
-				yum install -y "#{p}"
+			if (yum info "#{p[0]}"); then
+				yum install -y "#{p[0]}"
+			else
+				yum install -y "#{p[1]}"
 			fi
 		EOS
 	end

--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -59,4 +59,4 @@ end
 
 # Make any other instances aware of us
 #
-execute "/usr/local/bin/pick-job-server.sh"
+execute "/usr/local/bin/pick-job-server.sh || true"

--- a/recipes/ckanweb-configure.rb
+++ b/recipes/ckanweb-configure.rb
@@ -23,7 +23,3 @@
 include_recipe "datashades::ckan-configure"
 include_recipe "datashades::httpd-configure"
 include_recipe "datashades::nginx-configure"
-
-service 'php-fpm-5.5' do
-    action [:restart]
-end

--- a/recipes/ckanweb-setup.rb
+++ b/recipes/ckanweb-setup.rb
@@ -67,7 +67,7 @@ end
 
 execute "Remove unused Apache modules" do
     cwd "#{httpd_conf_dir}/conf.modules.d"
-    command "mv *-dav.conf *-lua.conf *-php.conf* *-proxy.conf ../conf.modules.disabled/ || echo 'Module(s) already disabled'"
+    command "mv *-dav.conf *-lua.conf *-php.conf* *-proxy.conf *-proxy_*.conf ../conf.modules.disabled/ || echo 'Module(s) already disabled'"
 end
 
 # Enable Apache service

--- a/recipes/ckanweb-setup.rb
+++ b/recipes/ckanweb-setup.rb
@@ -25,10 +25,10 @@ node['datashades']['ckan_web']['packages'].each do |p|
     package p
 end
 
-include_recipe "datashades::httpd-efs-setup"
-include_recipe "datashades::ckanweb-efs-setup"
-include_recipe "datashades::nginx-setup"
 include_recipe "datashades::ckan-setup"
+include_recipe "datashades::ckanweb-efs-setup"
+include_recipe "datashades::httpd-efs-setup"
+include_recipe "datashades::nginx-setup"
 
 httpd_conf_dir = "/etc/httpd"
 

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -85,6 +85,11 @@ service 'aws-smtp-relay' do
 end
 
 # Re-enable and start in case it was stopped by previous recipe versions
-service 'sendmail' do
+if system('which postfix') then
+    mailer_daemon = 'postfix'
+else
+    mailer_daemon = 'sendmail'
+end
+service mailer_daemon do
     action [:enable, :start]
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,6 +58,12 @@ end
 
 # Install/remove core packages
 #
+node['datashades']['core']['unwanted-packages'].each do |p|
+    package p do
+        action :remove
+    end
+end
+
 node['datashades']['core']['packages'].each do |p|
     package p
 end
@@ -91,12 +97,6 @@ end
 
 execute "Update AWS command-line interface" do
     command "pip --cache-dir=/tmp/ install --upgrade awscli"
-end
-
-node['datashades']['core']['unwanted-packages'].each do |p|
-    package p do
-        action :remove
-    end
 end
 
 # real basic stuff needs to go in first so jq available for new stack params that uses jq early on

--- a/recipes/nginx-setup.rb
+++ b/recipes/nginx-setup.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: datashades
 # Recipe:: nginx-setup
 #
-# Installs NGINX and PHP-FPM Web Server Role
+# Installs NGINX Web Server Role
 #
 # Copyright 2016, Link Digital
 #
@@ -30,20 +30,6 @@ end
 
 include_recipe "datashades::nginx-efs-setup"
 
-# Update php and nginx default config files
-#
-bash 'config_php' do
-	code <<-EOH
-		sed -i 's~127.0.0.1:9000~/tmp/phpfpm.sock~g' /etc/php-fpm-5.5.d/www.conf
-		sed -i 's~nobody~/tmp/phpfpm.sock~g' /etc/php-fpm-5.5.d/www.conf
-		sed -i 's~memory_limit = 128M~memory_limit = #{node['datashades']['nginx']['mem_limit']}~g' /etc/php-5.5.ini
-		sed -i "s~post_max_size = 8M~post_max_size = #{node['datashades']['nginx']['maxdl']}~g" /etc/php-5.5.ini
-		sed -i "s~upload_max_filesize = 2M~upload_max_filesize = #{node['datashades']['nginx']['maxdl']}~g" /etc/php-5.5.ini
-		echo -e "listen.owner = nginx\nlisten.group = nginx" >> /etc/php-fpm-5.5.d/www.conf
-		sed -i 's:default_server::g'  /etc/nginx/nginx.conf
-	EOH
-end
-
 # Create self-signed temporary SSL cert for Datashades
 #
 bash 'install ssl certs' do
@@ -56,11 +42,7 @@ end
 
 # Startup services
 #
-services = [ 'php-fpm-5.5', 'nginx']
-
-services.each do |servicename|
-	service servicename do
-		action [:enable, :start]
-	end
+service 'nginx' do
+	action [:enable, :start]
 end
 

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -6,14 +6,12 @@
 # following URL for a description of what they do and the full list of
 # available options:
 #
-# http://docs.ckan.org/en/ckan-2.2.1/configuration.html
+# http://docs.ckan.org/en/latest/maintaining/configuration.html
 #
 # The %(here)s variable will be replaced with the parent directory of this file
 #
 
 [DEFAULT]
-
-# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
 debug = false
 
 [server:main]
@@ -63,7 +61,6 @@ who.config_file = %(here)s/who.ini
 who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
-
 ## Database Settings
 sqlalchemy.url = postgresql://<%= node['datashades']['ckan_web']['dbuser'] %>:<%= node['datashades']['postgres']['password'] %>@<%= node['datashades']['version'] %>pg.<%= node['datashades']['tld'] %>/<%= node['datashades']['ckan_web']['dbname'] %>
 
@@ -86,15 +83,6 @@ ckan.site_url = https://<%= @app_url %><% node['datashades']['ckan_web']['endpoi
 ckan.user_reset_landing_page = /user/reset
 ckan.hide_version = True
 
-## QGOV Settings
-
-ckan.base_public_folder = public
-ckan.base_templates_folder = templates
-extra_public_paths = /var/www/sites/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/public
-extra_template_paths = /var/www/sites/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/templates
-feedback_form_recipients = <%= node['datashades']['ckan_web']['feedback_recipients'] %>
-feedback_redirection = <%= node['datashades']['ckan_web']['feedback_redirection'] %>
-
 ## Authorization Settings
 
 ckan.auth.anon_create_dataset = <%= node['datashades']['ckan_web']['auth']['anon_create_dataset'] %>
@@ -109,6 +97,14 @@ ckan.auth.create_user_via_web = <%= node['datashades']['ckan_web']['auth']['crea
 ckan.auth.roles_that_cascade_to_sub_groups = <%= node['datashades']['ckan_web']['auth']['roles_that_cascade_to_sub_groups'] %>
 ckan.auth.public_user_details = False
 
+## QGOV Settings
+
+ckan.base_public_folder = public
+ckan.base_templates_folder = templates
+extra_public_paths = /var/www/sites/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/public
+extra_template_paths = /var/www/sites/<%= node['datashades']['app_id'] %>-<%= node['datashades']['version'] %>/templates
+feedback_form_recipients = <%= node['datashades']['ckan_web']['feedback_recipients'] %>
+feedback_redirection = <%= node['datashades']['ckan_web']['feedback_redirection'] %>
 
 ## Search Settings
 
@@ -117,13 +113,16 @@ solr_url = http://<%= node['datashades']['app_id'] %>solr.<%= node['datashades']
 
 #ckan.simple_search = 1
 
+## Redis Settings
+
+ckan.redis.url = redis://<%= node['datashades']['redis']['hostname'] %>:<%= node['datashades']['redis']['port'] %>/0
 
 ## Plugins Settings
 
 # Note: Add ``datastore`` to enable the CKAN DataStore
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``pdf_preview`` to enable the resource preview for PDFs
-#       Add ``resource_proxy`` to enable resorce proxying and get around the
+#       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 ckan.plugins = stats resource_proxy text_preview recline_preview text_view webpage_view recline_grid_view image_view recline_view recline_graph_view recline_map_view
 
@@ -220,7 +219,6 @@ ckanext.validation.run_on_update_sync = False
 ckanext.validation.formats = csv xlsx xls
 
 ## Internationalisation Settings
-
 ckan.locale_default = en_AU
 ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
 ckan.locales_offered =
@@ -294,8 +292,6 @@ ckan.group_and_organization_list_all_fields_max = 100
 #ckan.datapusher.formats =
 ckan.datapusher.url = http://<%= node['datashades']['app_id'] %>datapusher.<%= node['datashades']['tld'] %>:8800/
 
-ckan.redis.url = redis://<%= node['datashades']['redis']['hostname'] %>:<%= node['datashades']['redis']['port'] %>/0
-
 ckanext.xloader.compatibility_mode = True
 
 ## Activity Streams Settings
@@ -303,7 +299,7 @@ ckanext.xloader.compatibility_mode = True
 ckan.activity_streams_enabled = true
 #ckan.activity_list_limit = 31
 #ckan.activity_streams_email_notifications = true
-# ckan.email_notifications_since = 2 days
+#ckan.email_notifications_since = 2 days
 
 
 ## Email settings

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -94,32 +94,6 @@
                 rewrite ^ /index.php;
         }
 
-        location ~ \.php$
-        {
-        		# error 418 used to rewrite php file URIs from migrated sites.
-				error_page 418 = @rewrite;
-				recursive_error_pages on;
-
-				fastcgi_split_path_info ^[^=](.+\.php)(/.+)$;
-				include fastcgi_params;
-
-				if ( $uri = /index.php )
-				{
-				        break;
-				}
-
-				if (!-e $document_root$fastcgi_script_name)
-				{
-				        return 418;
-				}
-
-                fastcgi_param SCRIPT_FILENAME $request_filename;
-				fastcgi_param PHP_VALUE "upload_max_filesize=<%= node['datashades']['nginx']['maxdl'] %> \n post_max_size=<%= node['datashades']['nginx']['maxdl'] %>";
-                fastcgi_intercept_errors on;
-                fastcgi_pass unix:/tmp/phpfpm.sock;
-				fastcgi_read_timeout 300;
-        }
-
         location ~* \.(js|css|png|jpg|jpeg|gif|ico)$
         {
                 expires max;


### PR DESCRIPTION
- Install the correct packages for Amazon Linux 1 or 2, according to what is present.
- Drop PHP as it's not needed and greatly complicates things.
- Ensure NFS client libraries are installed before connecting to Amazon EFS.
- Use Postfix instead of Sendmail if present.
- Clean up CKAN config.