### PR TITLE
[QOL-9159] use XLoader flag name consistent with upstream

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -292,7 +292,7 @@ ckan.group_and_organization_list_all_fields_max = 100
 #ckan.datapusher.formats =
 ckan.datapusher.url = http://<%= node['datashades']['app_id'] %>datapusher.<%= node['datashades']['tld'] %>:8800/
 
-ckanext.xloader.compatibility_mode = True
+ckanext.xloader.just_load_with_messytables = True
 
 ## Activity Streams Settings
 


### PR DESCRIPTION
Once we adjust this, we'll be a step closer to the possibility of using vanilla XLoader instead of a fork.