### PR TITLE
QOL-9055 update Solr recipes to prepare for Amazon Linux 2

### DIFF
--- a/recipes/ckanbatch-setup.rb
+++ b/recipes/ckanbatch-setup.rb
@@ -41,16 +41,7 @@ bash "Enable Supervisor file inclusions" do
 end
 
 # Configure either initd or systemd
-if ::File.exist? "/etc/init.d/supervisord" then
-	# Managed processes sometimes don't shut down properly on daemon stop,
-	# leaving them 'orphaned' and resulting in duplicates.
-	# Work around by issuing a stop command to the children first.
-	execute "Stop children on supervisord stop" do
-		command <<-'SED'.strip + " /etc/init.d/supervisord"
-			sed -i 's/^\(\s*\)\(killproc\)/\1timeout 10s supervisorctl stop all || echo "WARNING: Unable to stop managed process(es) - check for orphans"; \2/'
-		SED
-	end
-else
+if system('which systemctl')
 	systemd_unit "supervisord.service" do
 		content({
 			Unit: {
@@ -71,5 +62,14 @@ else
 			}
 		})
 		action [:create, :enable]
+	end
+else
+	# Managed processes sometimes don't shut down properly on daemon stop,
+	# leaving them 'orphaned' and resulting in duplicates.
+	# Work around by issuing a stop command to the children first.
+	execute "Stop children on supervisord stop" do
+		command <<-'SED'.strip + " /etc/init.d/supervisord"
+			sed -i 's/^\(\s*\)\(killproc\)/\1timeout 10s supervisorctl stop all || echo "WARNING: Unable to stop managed process(es) - check for orphans"; \2/'
+		SED
 	end
 end

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -188,14 +188,4 @@ datashades_move_and_link(var_data_dir) do
     owner service_name
 end
 
-# Create Monit config file to restart Solr when port 8983 not available
-# Solves instance start issue after Solr install when /data doesn't mount fast enough
-#
-cookbook_file '/etc/monit.d/solr.monitrc' do
-    source 'solr.monitrc'
-    owner 'root'
-    group 'root'
-    mode '0755'
-end
-
 include_recipe "datashades::solr-deploycore"


### PR DESCRIPTION
- Use an account ID that won't clash with new AMI
- Stop running Solr instances before modifying account
- Make detection of initd vs systemd more robust (don't rely on conditions that might change partway through execution)
