### PR TITLE
[QOL-9055] ensure Solr log dir has correct permissions

### DIFF
--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -37,7 +37,7 @@ end
 
 if not system("grep '^#{account_name}:x:2001' /etc/passwd") then
     execute "Stop Solr processes before modifying account" do
-        command "ps -U solr -o pid |tail -1 |xargs kill; sleep 1"
+        command "ps -U solr -o pid |tail -1 |xargs kill; sleep 2"
     end
 
     user account_name do

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -101,10 +101,6 @@ unless ::File.identical?(installed_solr_version, solr_path)
     end
 end
 
-execute "Ensure EFS directory ownership is correct" do
-    command "chown -R #{account_name}:#{account_name} #{efs_data_dir} #{var_data_dir}/ #{solr_environment_file}"
-end
-
 log4j_version = '2.17.1'
 for jar_type in ['1.2-api', 'api', 'core', 'slf4j-impl'] do
     log4j_artefact = "log4j-#{jar_type}"
@@ -186,6 +182,10 @@ datashades_move_and_link(var_data_dir) do
     target real_data_dir
     client_service service_name
     owner service_name
+end
+
+execute "Ensure directory ownership is correct" do
+    command "chown -R #{account_name}:ec2-user #{efs_data_dir} #{real_data_dir} #{solr_environment_file} #{real_log_dir}"
 end
 
 include_recipe "datashades::solr-deploycore"

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -36,8 +36,14 @@ group account_name do
 end
 
 if not system("grep '^#{account_name}:x:2001' /etc/passwd") then
-    execute "Stop Solr processes before modifying account" do
-        command "ps -U solr -o pid |tail -1 |xargs kill; sleep 2"
+    bash "Stop Solr processes before modifying account" do
+        code <<-EOS
+            ps -U solr -o pid |tail -1 |xargs kill
+            for {1..30}; do
+                ps -U solr > /dev/null 2>&1 || break
+                sleep 1
+            done
+        EOS
     end
 
     user account_name do


### PR DESCRIPTION
- We need to update this when changing Solr account ID for Amazon Linux 2
- Allow ec2-user to have group access so it's easier to read files