### PR TITLE
QOL-9055 fix Solr shutdown syntax

### DIFF
--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -39,7 +39,7 @@ if not system("grep '^#{account_name}:x:2001' /etc/passwd") then
     bash "Stop Solr processes before modifying account" do
         code <<-EOS
             ps -U solr -o pid= |xargs kill
-            for {1..30}; do
+            for i in {1..30}; do
                 ps -U solr > /dev/null 2>&1 || break
                 sleep 1
             done

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -38,7 +38,7 @@ end
 if not system("grep '^#{account_name}:x:2001' /etc/passwd") then
     bash "Stop Solr processes before modifying account" do
         code <<-EOS
-            ps -U solr -o pid |tail +1 |xargs kill
+            ps -U solr -o pid= |xargs kill
             for {1..30}; do
                 ps -U solr > /dev/null 2>&1 || break
                 sleep 1


### PR DESCRIPTION
- Use 'ps' built-in options instead of 'tail' so we can robustly handle empty output
- Fix shell loop syntax