### PR TITLE
QOL-9055 fix bugs

### DIFF
--- a/recipes/ckan-deploy.rb
+++ b/recipes/ckan-deploy.rb
@@ -75,6 +75,10 @@ execute "Pin setuptools version" do
 	command "#{virtualenv_dir}/bin/pip install setuptools==44.1.0"
 end
 
+execute "Pin pyOpenSSL version" do
+	command "#{virtualenv_dir}/bin/pip install pyOpenSSL==21.0.0"
+end
+
 datashades_pip_install_app "ckan" do
 	type app['app_source']['type']
 	revision app['app_source']['revision']

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -207,9 +207,9 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 		user "#{account_name}"
 		code <<-EOS
 			export PASTER_PLUGIN=ckanext-ytp-comments
-			#{ckan_cli} initdb || echo 'Ignoring expected error'
-			#{ckan_cli} init_notifications_db || echo 'Ignoring expected error'
-			#{ckan_cli} updatedb || echo 'Ignoring expected error'
+			#{ckan_cli} comments initdb || echo 'Ignoring expected error'
+			#{ckan_cli} comments init_notifications_db || echo 'Ignoring expected error'
+			#{ckan_cli} comments updatedb || echo 'Ignoring expected error'
 		EOS
 		only_if { "#{pluginname}".eql? 'ytp-comments' }
 	end


### PR DESCRIPTION
- Make YTP Comments database setup compatible with Click
- Pin 'pyOpenSSL' to a version that supports the latest 'cryptography'.