### PR TITLE
[QOLDEV-347] set the new version of the XLoader type guessing flag

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -298,6 +298,7 @@ ckan.datapusher.url = http://<%= node['datashades']['app_id'] %>datapusher.<%= n
 
 # Set both old and new versions of this flag
 ckanext.xloader.use_type_guessing = True
+# Deprecated, remove after upgrading XLoader to 0.12+
 ckanext.xloader.just_load_with_messytables = True
 
 ## Activity Streams Settings

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -296,6 +296,8 @@ ckan.group_and_organization_list_all_fields_max = 100
 #ckan.datapusher.formats =
 ckan.datapusher.url = http://<%= node['datashades']['app_id'] %>datapusher.<%= node['datashades']['tld'] %>:8800/
 
+# Set both old and new versions of this flag
+ckanext.xloader.use_type_guessing = True
 ckanext.xloader.just_load_with_messytables = True
 
 ## Activity Streams Settings


### PR DESCRIPTION
- We can set both the new and old flags (`use_type_guessing` and `just_load_with_messytables`), for compatibility.