### PR TITLE
[QOLDEV-329] add support for CKAN-version-specific requirements files

### DIFF
--- a/resources/pip_install_app.rb
+++ b/resources/pip_install_app.rb
@@ -107,11 +107,17 @@ action :create do
         cwd install_dir
         code <<-EOS
             PYTHON_MAJOR_VERSION=$(#{virtualenv_dir}/bin/python -c "import sys; print(sys.version_info.major)")
-            PY2_REQUIREMENTS_FILE=requirements-py2.txt
-            if [ "$PYTHON_MAJOR_VERSION" = "2" ] && [ -f $PY2_REQUIREMENTS_FILE ]; then
-                REQUIREMENTS_FILE=$PY2_REQUIREMENTS_FILE
+            PYTHON_REQUIREMENTS_FILE=requirements-py$PYTHON_MAJOR_VERSION.txt
+            if [ -f $PYTHON_REQUIREMENTS_FILE ]; then
+                REQUIREMENTS_FILE=$PYTHON_REQUIREMENTS_FILE
             else
-                REQUIREMENTS_FILE=requirements.txt
+                CKAN_MINOR_VERSION=$(#{virtualenv_dir}/bin/python -c "import ckan; print(ckan.__version__)" | grep -o '^[0-9]*[.][0-9]*')
+                CKAN_REQUIREMENTS_FILE=requirements-$CKAN_MINOR_VERSION.txt
+                if [ -f "$CKAN_REQUIREMENTS_FILE" ]; then
+                    REQUIREMENTS_FILE=$CKAN_REQUIREMENTS_FILE
+                else
+                    REQUIREMENTS_FILE=requirements.txt
+                fi
             fi
             if [ -f "$REQUIREMENTS_FILE" ]; then
                 #{pip} install -r $REQUIREMENTS_FILE


### PR DESCRIPTION
- Recognise the CKAN minor version (eg 2.9) and check for a specific requirement file for that version (requirements-2.9.txt)
- Extend the py2 support to cover any Python major version, if a specific file exists