### PR TITLE
QOLDEV-455 introduce recaptcha keys to ckan core

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -177,8 +177,8 @@ ckan.resource_proxy.chunk_size = 8192
 # package_hide_extras = for_search_index_only
 #package_edit_return_url = http://another.frontend/dataset/<NAME>
 #package_new_return_url = http://another.frontend/dataset/<NAME>
-#ckan.recaptcha.publickey =
-#ckan.recaptcha.privatekey =
+ckan.recaptcha.publickey = ${ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/recaptcha.publickey}
+ckan.recaptcha.privatekey = ${ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/recaptcha.privatekey}
 #licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
 # ckan.template_footer_end =
 


### PR DESCRIPTION
Load keys from SSM (v2 key's).  per https://docs.ckan.org/en/2.9/maintaining/configuration.html#ckan-recaptcha-publickey 