### PR TITLE
[CHDEXCHAE-60] move QGOV theme plugin to the top of the list

### DIFF
--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -90,9 +90,9 @@ extextras =
 #
 extordering =
 {
+	'data_qld data_qld_google_analytics' => 1,
 	'dcat structured_data' => 5,
 	'validation' => 10,
-	'data_qld data_qld_google_analytics' => 15,
 	'resource_type_validation' => 20,
 	'validation_schema_generator' => 21,
 	'qgovext' => 25,


### PR DESCRIPTION
- Our templates should override any others.

In particular, ckanext-validation overrides the resource_view template without calling `super()`, so we need to get in first.