### PR TITLE
[QOLDEV-517] fix token revocation edge case

### DIFF
--- a/templates/default/ckan-email-notifications.sh.erb
+++ b/templates/default/ckan-email-notifications.sh.erb
@@ -18,7 +18,7 @@ if [ -f "$VIRTUAL_ENV/bin/ckan" ]; then
 
     # revoke token afterward since it's not stored anywhere anyway
     TOKEN_ID=$($VIRTUAL_ENV/bin/ckan_cli user token list $ACCOUNT 2>/dev/null | grep "$TOKEN_NAME" |head -1 |awk '{print $1}' | tr -d '[]')
-    $VIRTUAL_ENV/bin/ckan_cli user token revoke $TOKEN_ID
+    $VIRTUAL_ENV/bin/ckan_cli user token revoke -- $TOKEN_ID
   fi
 else
   # CKAN <= 2.8


### PR DESCRIPTION
- Add '--' to the revoke command, so that tokens starting with hyphens won't be mistakenly treated as options. See POSIX conventions guideline 10 at https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html