### PR TITLE
[QOLDEV-627] put Solr backup directory inside Solr home

### DIFF
--- a/templates/default/solr-env.sh.erb
+++ b/templates/default/solr-env.sh.erb
@@ -8,7 +8,7 @@ HEARTBEAT_FILE="/data/solr-healthcheck_$opsworks_hostname"
 STARTUP_FILE="$HEARTBEAT_FILE.start"
 
 EXTRA_DISK="/mnt/local_data"
-LOCAL_DIR="$EXTRA_DISK/solr_backup"
+LOCAL_DIR="/var/solr/data/solr_backup"
 DATA_DIR="$EXTRA_DISK/solr_data/data/$CORE_NAME/data"
 SYNC_DIR="/data/solr/data/$CORE_NAME/data"
 HOST="http://localhost:8983/solr"


### PR DESCRIPTION
- Solr 8 will restrict access to directories outside SOLR_HOME, so we need to either move backups there or specifically configure an exception