### PR TITLE
[QOLDEV-638] add config flags to control data request notifications

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -187,6 +187,8 @@ ckan.datarequests.show_datarequests_badge = true
 ckan.datarequests.description_required = true
 ckan.datarequests.default_organisation = open-data-administration-data-requests
 ckan.datarequests.enable_closing_circumstances = True
+ckanext.datarequests.notify_all_members = False
+ckanext.datarequests.notify_on_update = True
 
 ckan.odi_certificates.certificate_base_url = https://certificates.theodi.org/en/datasets?
 ckan.odi_certificates.certificate_img_query_parameters = {"datasetUrl":"", "format":"png", "type":"badge"}


### PR DESCRIPTION
- Data request notification functionality is moving into ckanext-datarequest, controlled by config, instead of being overridden by ckanext-data-qld.