### PR TITLE
Include ckanext-validation-schema-generator api_key 

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -305,6 +305,15 @@ ckanext.xloader.use_type_guessing = True
 # Deprecated, remove after upgrading XLoader to 0.12+
 ckanext.xloader.just_load_with_messytables = True
 
+
+#ckanext-validation-schema-generator
+# If the resource is remote or private, we could pass an API key inside headers
+# This option defines should we pass API key or not
+# (optional, default: True).
+ckanext.validation_schema_generator.pass_api_key = True
+# API key that is going to be passed for `Authorization`
+ckanext.validation_schema_generator.api_key = ${ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/job_token}
+
 ## Activity Streams Settings
 
 ckan.activity_streams_enabled = true


### PR DESCRIPTION
so it can work with private resources that need auth to download