### PR TITLE
QOLDEV-653 fix Solr replication errors

### DIFF
--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -61,6 +61,7 @@ function import_snapshot () {
     if [ -f "$SYNC_SNAPSHOT/write.lock" ]; then
       sudo -u solr rm -r $LOCAL_DIR/snapshot.$CORE_NAME-*
       sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT/" "$LOCAL_SNAPSHOT/" || exit 1
+      rm $LOCAL_SNAPSHOT/write.lock
       curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
       return 1
     else

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -6,8 +6,8 @@ set -x
 
 BACKUP_NAME="$CORE_NAME-$(date +'%Y-%m-%dT%H:%M')"
 SNAPSHOT_NAME="snapshot.$BACKUP_NAME"
-LOCAL_SNAPSHOT="$LOCAL_DIR/$SNAPSHOT_NAME/"
-SYNC_SNAPSHOT="$SYNC_DIR/$SNAPSHOT_NAME/"
+LOCAL_SNAPSHOT="$LOCAL_DIR/$SNAPSHOT_NAME"
+SYNC_SNAPSHOT="$SYNC_DIR/$SNAPSHOT_NAME"
 MINUTE=$(date +%M)
 
 function set_dns_primary () {
@@ -28,7 +28,7 @@ function wait_for_replication_success () {
   for i in $(eval echo "{1..$MAX_BACKUP_WAIT}"); do
     if [ "$BACKUP_STATUS" = "unknown" ]; then
       DETAILS=$(curl "$HOST/$CORE_NAME/replication?command=details")
-      echo "Backup status: $DETAILS"
+      echo "Backup status on attempt $i: $DETAILS"
       if (echo "$DETAILS" |grep "$BACKUP_NAME"); then
         echo "$DETAILS" |grep 'status[^a-zA-Z]*success' && return 0
         echo "$DETAILS" |grep "exception.*$CORE_NAME" && return 1
@@ -52,7 +52,23 @@ function export_snapshot () {
   if [ "$REPLICATION_STATUS" != "0" ]; then
     return $REPLICATION_STATUS
   fi
-  sudo -u solr sh -c "$LUCENE_CHECK $LOCAL_SNAPSHOT && rsync -a --delete $LOCAL_SNAPSHOT $SYNC_SNAPSHOT" || return 1
+  sudo -u solr sh -c "$LUCENE_CHECK $LOCAL_SNAPSHOT && rsync -a --delete $LOCAL_SNAPSHOT/ $SYNC_SNAPSHOT/" || return 1
+}
+
+function import_snapshot () {
+  # Give the master time to update the sync copy
+  for i in $(eval echo "{1..40}"); do
+    if [ -f "$SYNC_SNAPSHOT/write.lock" ]; then
+      sudo -u solr rm -r $LOCAL_DIR/snapshot.$CORE_NAME-*
+      sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT/" "$LOCAL_SNAPSHOT/" || exit 1
+      curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
+      return 1
+    else
+      sleep 5
+    fi
+  done
+  echo "Snapshot did not become available for import: $SYNC_SNAPSHOT"
+  return 1
 }
 
 # we can't perform any replication operations if Solr is stopped
@@ -90,12 +106,9 @@ if (/usr/local/bin/pick-solr-master.sh); then
 else
   # make traffic come to this instance only as a backup option
   set_dns_primary false
-  # Give the master time to update the sync copy; run halfway between exports
-  sleep 30
-  if [ -d "$SYNC_SNAPSHOT" ]; then
-    sudo -u solr rm -r $LOCAL_DIR/snapshot.$CORE_NAME-*
-    sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT" "$LOCAL_SNAPSHOT" || exit 1
-    curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
-  fi
+  import_snapshot
 fi
-sudo -u solr rm -r $(ls -d $LOCAL_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME")
+OLD_SNAPSHOTS=$(ls -d $LOCAL_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME")
+if [ "$OLD_SNAPSHOTS" != "" ]; then
+    sudo -u solr rm -r $OLD_SNAPSHOTS
+fi


### PR DESCRIPTION
- Drop the lock file before importing, to avoid Solr trying to load it like a segment.
- Make replication more robust in handling long export times.