### PR TITLE
QOLSVC-3914 fix logout CSRF tokens

### DIFF
--- a/recipes/ckan-deploy.rb
+++ b/recipes/ckan-deploy.rb
@@ -56,7 +56,7 @@ paths.each do |nfs_path, dir_owner|
 		owner dir_owner
 		group service_name
 		recursive true
-		mode '0775'
+		mode '0755'
 		action :create
 	end
 end

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -363,16 +363,6 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 			user "#{account_name}"
 			command "sed -i 's|^\\(use\s*=\\)\\(.*:FriendlyFormPlugin\\)|#\\1\\2\\n\\1 ckanext.csrf_filter.token_protected_friendlyform:TokenProtectedFriendlyFormPlugin|g' #{config_dir}/who.ini"
 		end
-
-		bash "Disable built-in CKAN CSRF filter" do
-			user "#{account_name}"
-			cwd "#{config_dir}"
-			code <<-EOS
-				if [ -z "$(grep 'WTF_CSRF_ENABLED' #{config_file})" ]; then
-					echo "WTF_CSRF_ENABLED = False" >> #{config_file}
-				fi
-			EOS
-		end
 	end
 
 	# Viewhelpers is a special case because stats needs to be loaded before it

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -82,6 +82,7 @@ ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/allowed_functions.txt
 ckan.site_url = https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>
 ckan.user_reset_landing_page = /user/reset
 ckan.hide_version = True
+WTF_CSRF_ENABLED = False
 
 ## Authorization Settings
 


### PR DESCRIPTION
Disable the core CSRF filter properly instead of conditionally injecting config in the wrong place.