### PR TITLE
Develop to master - disable core CSRF filter properly

### DIFF
--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -6,8 +6,8 @@ set -x
 
 BACKUP_NAME="$CORE_NAME-$(date +'%Y-%m-%dT%H:%M')"
 SNAPSHOT_NAME="snapshot.$BACKUP_NAME"
-LOCAL_SNAPSHOT="$LOCAL_DIR/$SNAPSHOT_NAME/"
-SYNC_SNAPSHOT="$SYNC_DIR/$SNAPSHOT_NAME/"
+LOCAL_SNAPSHOT="$LOCAL_DIR/$SNAPSHOT_NAME"
+SYNC_SNAPSHOT="$SYNC_DIR/$SNAPSHOT_NAME"
 MINUTE=$(date +%M)
 
 function set_dns_primary () {
@@ -28,7 +28,7 @@ function wait_for_replication_success () {
   for i in $(eval echo "{1..$MAX_BACKUP_WAIT}"); do
     if [ "$BACKUP_STATUS" = "unknown" ]; then
       DETAILS=$(curl "$HOST/$CORE_NAME/replication?command=details")
-      echo "Backup status: $DETAILS"
+      echo "Backup status on attempt $i: $DETAILS"
       if (echo "$DETAILS" |grep "$BACKUP_NAME"); then
         echo "$DETAILS" |grep 'status[^a-zA-Z]*success' && return 0
         echo "$DETAILS" |grep "exception.*$CORE_NAME" && return 1
@@ -52,7 +52,24 @@ function export_snapshot () {
   if [ "$REPLICATION_STATUS" != "0" ]; then
     return $REPLICATION_STATUS
   fi
-  sudo -u solr sh -c "$LUCENE_CHECK $LOCAL_SNAPSHOT && rsync -a --delete $LOCAL_SNAPSHOT $SYNC_SNAPSHOT" || return 1
+  sudo -u solr sh -c "$LUCENE_CHECK $LOCAL_SNAPSHOT && rsync -a --delete $LOCAL_SNAPSHOT/ $SYNC_SNAPSHOT/" || return 1
+}
+
+function import_snapshot () {
+  # Give the master time to update the sync copy
+  for i in $(eval echo "{1..40}"); do
+    if [ -f "$SYNC_SNAPSHOT/write.lock" ]; then
+      sudo -u solr rm -r $LOCAL_DIR/snapshot.$CORE_NAME-*
+      sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT/" "$LOCAL_SNAPSHOT/" || exit 1
+      rm $LOCAL_SNAPSHOT/write.lock
+      curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
+      return 1
+    else
+      sleep 5
+    fi
+  done
+  echo "Snapshot did not become available for import: $SYNC_SNAPSHOT"
+  return 1
 }
 
 # we can't perform any replication operations if Solr is stopped
@@ -90,12 +107,9 @@ if (/usr/local/bin/pick-solr-master.sh); then
 else
   # make traffic come to this instance only as a backup option
   set_dns_primary false
-  # Give the master time to update the sync copy; run halfway between exports
-  sleep 30
-  if [ -d "$SYNC_SNAPSHOT" ]; then
-    sudo -u solr rm -r $LOCAL_DIR/snapshot.$CORE_NAME-*
-    sudo -u solr rsync -a --delete "$SYNC_SNAPSHOT" "$LOCAL_SNAPSHOT" || exit 1
-    curl "$HOST/$CORE_NAME/replication?command=restore&location=$LOCAL_DIR&name=$BACKUP_NAME"
-  fi
+  import_snapshot
 fi
-sudo -u solr rm -r $(ls -d $LOCAL_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME")
+OLD_SNAPSHOTS=$(ls -d $LOCAL_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME")
+if [ "$OLD_SNAPSHOTS" != "" ]; then
+    sudo -u solr rm -r $OLD_SNAPSHOTS
+fi

--- a/recipes/ckan-deploy.rb
+++ b/recipes/ckan-deploy.rb
@@ -56,7 +56,7 @@ paths.each do |nfs_path, dir_owner|
 		owner dir_owner
 		group service_name
 		recursive true
-		mode '0775'
+		mode '0755'
 		action :create
 	end
 end

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -363,16 +363,6 @@ search("aws_opsworks_app", 'shortname:*ckanext*').each do |app|
 			user "#{account_name}"
 			command "sed -i 's|^\\(use\s*=\\)\\(.*:FriendlyFormPlugin\\)|#\\1\\2\\n\\1 ckanext.csrf_filter.token_protected_friendlyform:TokenProtectedFriendlyFormPlugin|g' #{config_dir}/who.ini"
 		end
-
-		bash "Disable built-in CKAN CSRF filter" do
-			user "#{account_name}"
-			cwd "#{config_dir}"
-			code <<-EOS
-				if [ -z "$(grep 'WTF_CSRF_ENABLED' #{config_file})" ]; then
-					echo "WTF_CSRF_ENABLED = False" >> #{config_file}
-				fi
-			EOS
-		end
 	end
 
 	# Viewhelpers is a special case because stats needs to be loaded before it

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -82,6 +82,7 @@ ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/allowed_functions.txt
 ckan.site_url = https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>
 ckan.user_reset_landing_page = /user/reset
 ckan.hide_version = True
+WTF_CSRF_ENABLED = False
 
 ## Authorization Settings
 

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -305,6 +305,15 @@ ckanext.xloader.use_type_guessing = True
 # Deprecated, remove after upgrading XLoader to 0.12+
 ckanext.xloader.just_load_with_messytables = True
 
+
+#ckanext-validation-schema-generator
+# If the resource is remote or private, we could pass an API key inside headers
+# This option defines should we pass API key or not
+# (optional, default: True).
+ckanext.validation_schema_generator.pass_api_key = True
+# API key that is going to be passed for `Authorization`
+ckanext.validation_schema_generator.api_key = ${ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/job_token}
+
 ## Activity Streams Settings
 
 ckan.activity_streams_enabled = true


### PR DESCRIPTION
Config to disable the CSRF filter was being injected into the config file in the wrong place, at the end of the logging configuration, and consequently did not work.