### PR TITLE
[QOLDEV-684] check for the presence of an underscore in Click command before trying it

### DIFF
--- a/files/default/ckan_cli
+++ b/files/default/ckan_cli
@@ -62,8 +62,10 @@ if [ "$COMMAND" = "ckan" ]; then
     shift
     CLICK_COMMAND=$1
     if [ "$CLICK_COMMAND" != "" ]; then
-        # handle change of expectations from underscore to hyphen in Click 7+
-        $ENV_DIR/ckan -c ${CKAN_INI} $ENTRYPOINT $CLICK_COMMAND --help >/dev/null 2>&1 || CLICK_COMMAND=$(echo $CLICK_COMMAND | sed 's/_/-/g');
+        if (echo "$CLICK_COMMAND" | grep '_' >/dev/null); then
+            # handle change of expectations from underscore to hyphen in Click 7+
+            $ENV_DIR/ckan -c ${CKAN_INI} $ENTRYPOINT $CLICK_COMMAND --help >/dev/null 2>&1 || CLICK_COMMAND=$(echo $CLICK_COMMAND | sed 's/_/-/g');
+        fi
         shift
     fi
     echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $ENTRYPOINT $CLICK_COMMAND $1..." >&2


### PR DESCRIPTION
- No point running a (slow) test for command name support if we don't have anything to act on