### PR TITLE
Develop to master - fix syntax for ignoring Solr snapshots

### DIFF
--- a/files/default/ckan_cli
+++ b/files/default/ckan_cli
@@ -62,8 +62,10 @@ if [ "$COMMAND" = "ckan" ]; then
     shift
     CLICK_COMMAND=$1
     if [ "$CLICK_COMMAND" != "" ]; then
-        # handle change of expectations from underscore to hyphen in Click 7+
-        $ENV_DIR/ckan -c ${CKAN_INI} $ENTRYPOINT $CLICK_COMMAND --help >/dev/null 2>&1 || CLICK_COMMAND=$(echo $CLICK_COMMAND | sed 's/_/-/g');
+        if (echo "$CLICK_COMMAND" | grep '_' >/dev/null); then
+            # handle change of expectations from underscore to hyphen in Click 7+
+            $ENV_DIR/ckan -c ${CKAN_INI} $ENTRYPOINT $CLICK_COMMAND --help >/dev/null 2>&1 || CLICK_COMMAND=$(echo $CLICK_COMMAND | sed 's/_/-/g');
+        fi
         shift
     fi
     echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $ENTRYPOINT $CLICK_COMMAND $1..." >&2

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -193,7 +193,7 @@ end
 # Use find+exec instead of chown's recursive -R flag,
 # so that we can exclude temporary snapshots.
 execute "Ensure directory ownership is correct" do
-    command "find #{efs_data_dir} #{real_data_dir} #{solr_environment_file} #{real_log_dir} -not -path data/*/snapshot* -execdir chown #{account_name}:ec2-user {} +"
+    command "find #{efs_data_dir} #{real_data_dir} #{solr_environment_file} #{real_log_dir} -not -path */data/*/snapshot* -execdir chown #{account_name}:ec2-user {} +"
 end
 
 include_recipe "datashades::solr-deploycore"


### PR DESCRIPTION
Fix the find command that is meant to exclude Solr snapshots from recursive ownership changes. Snapshots are ephemeral and thus do not need chown, and might disappear partway through attempting to apply it.