### PR TITLE
enable XLoader's automatic datastore cleanup on resources that no longer qualify

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -306,10 +306,8 @@ ckan.datapusher.url = http://<%= node['datashades']['app_id'] %>datapusher.<%= n
 
 ckanext.xloader.parse_dates_dayfirst = True
 ckanext.xloader.api_token = ${ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/job_token}
-# Set both old and new versions of this flag
 ckanext.xloader.use_type_guessing = True
-# Deprecated, remove after upgrading XLoader to 0.12+
-ckanext.xloader.just_load_with_messytables = True
+ckanext.xloader.clean_datastore_tables = True
 
 
 #ckanext-validation-schema-generator


### PR DESCRIPTION
Also drop obsolete type-guessing flag.