### PR TITLE
[QOLSVC-4667] make logrotate config update more robust

### DIFF
--- a/recipes/nginx-configure.rb
+++ b/recipes/nginx-configure.rb
@@ -26,7 +26,7 @@ execute "Extend Nginx log rotation" do
 	cwd "/etc/logrotate.d"
 	# this replacement needs to be idempotent; the result must not match the original pattern
 	# use single quotes so we don't have to double our backslashes
-	command 'sed -i "s|\(/var/log/nginx/\*log\) {|\1\n/var/log/nginx/*/*log {|" nginx'
+	command 'sed -i "s|\(/var/log/nginx/[*][.]\?log\) {|\1\n/var/log/nginx/*/*.log {|" nginx'
 end
 
 file "/etc/cron.daily/archive-nginx-logs-to-s3" do


### PR DESCRIPTION
- Handle existing log file expressions with or without a dot before the file extension. Failing to do so has resulted in log files not being rotated for years, and filling the disk.