### PR TITLE
[QOLSVC-4793] Add missing newline to ClamAV cleanup cron file

### DIFF
--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -81,7 +81,7 @@ file '/etc/cron.daily/manageadmins' do
 end
 
 file "/etc/cron.daily/clamav-tmp-file-cleanup" do
-	content "rm -r /var/lib/clamav/tmp.* >/dev/null 2>&1"
+	content "rm -r /var/lib/clamav/tmp.* >/dev/null 2>&1\n"
 	owner "root"
 	group "root"
 	mode "0755"


### PR DESCRIPTION
The cron file created to clean up ClamAV temp files daily was missing a required ending newline.