### PR TITLE
[QOLDEV-545] unfreeze app url string for modification if needed

### DIFF
--- a/resources/pip_install_app.rb
+++ b/resources/pip_install_app.rb
@@ -36,6 +36,7 @@ action :create do
     is_git = new_resource.type.casecmp("git") == 0
 
     apprelease = new_resource.url
+    apprelease = apprelease.dup if apprelease.frozen?
 
     # Get the version number from the app revision, by preference,
     # or from the app URL if revision is not defined.

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -125,7 +125,7 @@ ckan.redis.url = redis://<%= node['datashades']['redis']['hostname'] %>:<%= node
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 
-ckan.plugins = stats resource_proxy text_view webpage_view recline_grid_view image_view audio_view video_view recline_view recline_graph_view recline_map_view datatables_view
+ckan.plugins = stats resource_proxy text_view webpage_view image_view audio_view video_view datatables_view
 
 trak.display_pageviews = true
 


### PR DESCRIPTION
- Supplying the URL via custom JSON can result in it being frozen, but we need to manipulate it
- Also drop obsolete Recline plugin that will be removed in future versions