### PR TITLE
[QOLDEV-545] restructure chown command to exclude snapshots

### DIFF
--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -193,7 +193,7 @@ end
 # Use find+exec instead of chown's recursive -R flag,
 # so that we can exclude temporary snapshots.
 execute "Ensure directory ownership is correct" do
-    command "find #{efs_data_dir}/data/#{core_name} #{real_data_dir}/data/#{core_name} #{solr_environment_file} #{real_log_dir} -not -path */snapshot* -execdir chown #{account_name}:ec2-user {} +"
+    command "find #{efs_data_dir}/data/#{core_name} #{real_data_dir}/data/#{core_name} #{solr_environment_file} #{real_log_dir} |grep -vE 'snapshot|index' |xargs chown #{account_name}:ec2-user"
 end
 
 include_recipe "datashades::solr-deploycore"


### PR DESCRIPTION
- Filter paths with 'grep' instead of natively in 'find' to avoid complications with 'execdir' altering paths