### PR TITLE
QOLDEV-545 clean up cookbook for new servers

### DIFF
--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -403,16 +403,6 @@ node['datashades']['ckan_web']['plugin_apps'].each do |app|
 			user "#{account_name}"
 			command "#{pip} install numpy==1.15.4"
 		end
-
-		# The dateparser library defaults to month-first but is configurable.
-		# Unfortunately, simply toggling the day-first flag breaks ISO dates.
-		# See https://github.com/dateutil/dateutil/issues/402
-		execute "Patch date parser format" do
-			user "#{account_name}"
-			command <<-'SED'.strip + " #{virtualenv_dir}/lib/*/site-packages/messytables/types.py"
-				sed -i "s/^\(\s*\)return parser[.]parse(value)/\1try:\n\1    return parser.isoparse(value)\n\1except ValueError:\n\1    return parser.parse(value, dayfirst=True)/"
-			SED
-		end
 	end
 end
 

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -114,9 +114,9 @@ end
 bash "Install NPM and NodeJS" do
 	code <<-EOS
 		if ! (yum install -y npm); then
-			# failed to install from standard repo, try a manual setup
-			curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-			yum -y install nodejs
+			# TODO stop ignoring broken packages
+			# once we're away from OpsWorks and on a recent AMI
+			yum -y install nodejs --skip-broken
 		fi
 	EOS
 end

--- a/recipes/solr-deploycore.rb
+++ b/recipes/solr-deploycore.rb
@@ -52,9 +52,10 @@ cookbook_file "#{Chef::Config[:file_cache_path]}/solr_core_config.zip" do
 	source "ckan_solr_conf.zip"
 end
 
-service "solr stop" do
-    service_name "solr"
-	action [:stop]
+execute "solr stop" do
+	user 'root'
+	# Try both initd and systemd styles
+	command "(systemctl status solr >/dev/null 2>&1 && systemctl stop solr) || (service solr status >/dev/null 2>&1 && service solr stop)"
 end
 
 execute 'Unzip Core Config' do


### PR DESCRIPTION
- Make Solr restart more resilient to both old (initd) and new (systemd) management systems.
- Drop obsolete messytables patching (which results in an error when messytables was never installed).