### PR TITLE
[QOLDEV-545] fix Solr supervisord config

### DIFF
--- a/files/default/supervisor-solr.conf
+++ b/files/default/supervisor-solr.conf
@@ -9,7 +9,7 @@
 [program:solr]
 
 ; Use the full paths to the virtualenv and your configuration file here.
-command=/opt/solr/bin/solr start
+command=/opt/solr/bin/solr start -f
 
 ; User the worker runs as.
 user=solr
@@ -20,7 +20,7 @@ numprocs=1
 process_name=%(program_name)s-%(process_num)02d
 
 ; Log files.
-stdout_logfile=/var/log/solr/stdout.log
+stdout_logfile=/var/log/solr/solr.log
 stderr_logfile=/var/log/solr/stderr.log
 
 ; Make sure that the worker is started on system start and automatically


### PR DESCRIPTION
- Make Solr run in foreground so Supervisord can manage it
- Use the standard log file location