### PR TITLE
pin 'typer' library to avoid version clash

### DIFF
--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -492,6 +492,7 @@ bash "Pin 'click' version to make Goodtables and Frictionless coexist" do
 	code <<-EOS
 		if (#{pip} show click |grep 'Version: [1-6][.]') then
 			#{pip} install click==7.1.2
+			#{pip} install typer<0.12
 		fi
 	EOS
 end


### PR DESCRIPTION
- Typer 0.12+ relies on Click 8, which we aren't yet ready for