### PR TITLE
QOLDEV-545 look up plugin definitions just in time during deployment

### DIFF
--- a/recipes/ckanparams.rb
+++ b/recipes/ckanparams.rb
@@ -23,6 +23,8 @@
 # Obtain some stack attributes for the recipes to use
 #
 
+require 'json'
+
 include_recipe "datashades::stackparams"
 
 # Retrieve attributes from SSM Parameter Store
@@ -41,11 +43,7 @@ node.default['datashades']['postgres']['password'] = `aws ssm get-parameter --re
 
 node.default['datashades']['ckan_web']['plugin_app_names'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_app_names" --query "Parameter.Value" --output text`.strip.split(',')
 for plugin in node['datashades']['ckan_web']['plugin_app_names'] do
-    node.default['datashades']['ckan_web']['plugin_apps'][plugin]['name'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/name" --query "Parameter.Value" --output text`.strip
-    node.default['datashades']['ckan_web']['plugin_apps'][plugin]['shortname'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/shortname" --query "Parameter.Value" --output text`.strip
-    node.default['datashades']['ckan_web']['plugin_apps'][plugin]['app_source']['type'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/app_source/type" --query "Parameter.Value" --output text`.strip
-    node.default['datashades']['ckan_web']['plugin_apps'][plugin]['app_source']['url'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/app_source/url" --query "Parameter.Value" --output text`.strip
-    node.default['datashades']['ckan_web']['plugin_apps'][plugin]['app_source']['revision'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/app_source/revision" --query "Parameter.Value" --output text`.strip
+    node.default['datashades']['ckan_web']['plugin_apps'][plugin] = JSON.parse(`aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}" --query "Parameter.Value" --output text`)
 end
 
 # Derive defaults from other values

--- a/recipes/ckanparams.rb
+++ b/recipes/ckanparams.rb
@@ -23,8 +23,6 @@
 # Obtain some stack attributes for the recipes to use
 #
 
-require 'json'
-
 include_recipe "datashades::stackparams"
 
 # Retrieve attributes from SSM Parameter Store
@@ -40,11 +38,7 @@ node.default['datashades']['ckan_web']['adminpw'] = `aws ssm get-parameter --reg
 node.default['datashades']['ckan_web']['beaker_secret'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/beaker_secret" --query "Parameter.Value" --with-decryption --output text`.strip
 node.default['datashades']['ckan_web']['dbuser'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/db/#{node['datashades']['app_id']}_user" --query "Parameter.Value" --output text`.strip
 node.default['datashades']['postgres']['password'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/db/#{node['datashades']['app_id']}_password" --query "Parameter.Value" --with-decryption --output text`.strip
-
 node.default['datashades']['ckan_web']['plugin_app_names'] = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_app_names" --query "Parameter.Value" --output text`.strip.split(',')
-for plugin in node['datashades']['ckan_web']['plugin_app_names'] do
-    node.default['datashades']['ckan_web']['plugin_apps'][plugin] = JSON.parse(`aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}" --query "Parameter.Value" --output text`)
-end
 
 # Derive defaults from other values
 node.default['datashades']['ckan_web']['dsname'] = "#{node['datashades']['ckan_web']['dbname']}_datastore"

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -129,17 +129,17 @@ resource_visibility_present = false
 harvest_present = false
 csrf_present = false
 
-node['datashades']['ckan_web']['plugin_app_names'].each do |app|
+node['datashades']['ckan_web']['plugin_app_names'].each do |plugin|
 
-	egg_name = node['datashades']['ckan_web']['plugin_apps'][app]['shortname']
+	egg_name = `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/shortname" --query "Parameter.Value" --output text`.strip
 
 	# Install Extension
 	#
 
 	datashades_pip_install_app egg_name do
-		type node['datashades']['ckan_web']['plugin_apps'][app]['app_source']['type']
-		revision node['datashades']['ckan_web']['plugin_apps'][app]['app_source']['revision']
-		url node['datashades']['ckan_web']['plugin_apps'][app]['app_source']['url']
+		type `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/app_source/type" --query "Parameter.Value" --output text`.strip
+		revision `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/app_source/url" --query "Parameter.Value" --output text`.strip
+		url `aws ssm get-parameter --region "#{node['datashades']['region']}" --name "/config/CKAN/#{node['datashades']['version']}/app/#{node['datashades']['app_id']}/plugin_apps/#{plugin}/app_source/revision" --query "Parameter.Value" --output text`.strip
 	end
 
 	# Many extensions use a different name on the plugins line so these need to be managed


### PR DESCRIPTION
Populating parameters has slightly different syntax depending on whether it's custom JSON or Parameter Store. Simpler to just look up from Parameter Store during deployment.