### PR TITLE
QOLDEV-833 adjust recipes to better support 'warm' instances

### DIFF
--- a/recipes/ckan-configure.rb
+++ b/recipes/ckan-configure.rb
@@ -28,15 +28,3 @@ bash "Fix Python Install Layout" do
     EOS
     not_if "grep '# export PYTHON_INSTALL_LAYOUT' /etc/profile.d/python-install-layout.sh"
 end
-
-cookbook_file "/etc/logrotate.d/ckan" do
-    source "ckan-logrotate"
-end
-
-if not system("grep 'alias git=' ~/.bash_profile")
-    execute "Add CKAN Git alias to Bash" do
-        command <<-EOS
-            echo "alias git='sudo -u ckan git'" >> ~/.bash_profile
-        EOS
-    end
-end

--- a/recipes/ckan-deploy.rb
+++ b/recipes/ckan-deploy.rb
@@ -176,3 +176,8 @@ execute "Compile locale translation" do
 	cwd install_dir
 	command "#{virtualenv_dir}/bin/python setup.py compile_catalog -f --locale en_AU"
 end
+
+# Configure CKAN log processing
+cookbook_file "/etc/logrotate.d/ckan" do
+    source "ckan-logrotate"
+end

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -155,3 +155,12 @@ link "/etc/ckan/default" do
 	to "#{virtualenv_dir}/etc"
 	link_type :symbolic
 end
+
+# Add Bash alias to automatically use 'ckan' account for Git commands
+if not system("grep 'alias git=' ~/.bash_profile")
+    execute "Add CKAN Git alias to Bash" do
+        command <<-EOS
+            echo "alias git='sudo -u ckan git'" >> ~/.bash_profile
+        EOS
+    end
+end

--- a/recipes/ckanbatch-deploy.rb
+++ b/recipes/ckanbatch-deploy.rb
@@ -57,7 +57,7 @@ cookbook_file "/etc/supervisord.d/supervisor-ckan-worker.ini" do
     mode "0744"
 end
 
-# Set up maintenance cron jobs
+# Set up maintenance scripts needed for cron jobs
 
 cookbook_file "/usr/local/bin/archive-resource-revisions.sql" do
     source "archive-resource-revisions.sql"
@@ -105,46 +105,11 @@ template "/usr/local/bin/redis-backup.py" do
     mode "0755"
 end
 
-# Remove unwanted cron job
-file '/etc/cron.daily/ckan-tracking-update' do
-    action :delete
-end
-#
-# # Remove unwanted cron job from higher environments
-# file '/etc/cron.hourly/ckan-tracking-update' do
-#     action :delete
-#     not_if { node['datashades']['version'] == 'DEV' || node['datashades']['version'] == 'TEST' }
-# end
-
-# Only set cron job for lower environments
-file '/etc/cron.hourly/ckan-tracking-update' do
-    content "/usr/local/bin/pick-job-server.sh && #{ckan_cli} tracking update >/dev/null 2>&1\n"
+template "/usr/local/bin/ckan-monitor-job-queue.sh" do
+    source 'ckan-monitor-job-queue.sh.erb'
+    owner 'root'
+    group 'root'
     mode '0755'
-    owner "root"
-    group "root"
-    only_if { node['datashades']['version'] == 'DEV' || node['datashades']['version'] == 'TEST' }
-end
-
-# Run tracking update at 8:30am everywhere
-file "/etc/cron.d/ckan-tracking-update" do
-    content "30 8 * * * root /usr/local/bin/pick-job-server.sh && #{ckan_cli} tracking update >/dev/null 2>&1\n"
-    mode '0644'
-    owner "root"
-    group "root"
-end
-
-file "/etc/cron.hourly/ckan-email-notifications" do
-    content "/usr/local/bin/pick-job-server.sh && /usr/local/bin/ckan-email-notifications.sh > /dev/null 2>&1\n"
-    mode '0755'
-    owner "root"
-    group "root"
-end
-
-file "/etc/cron.daily/ckan-revision-archival" do
-    content "/usr/local/bin/pick-job-server.sh && /usr/local/bin/archive-resource-revisions.sh >/dev/null 2>&1\n"
-    mode '0755'
-    owner "root"
-    group "root"
 end
 
 service "supervisord restart" do

--- a/recipes/ckanbatch-setup.rb
+++ b/recipes/ckanbatch-setup.rb
@@ -21,3 +21,20 @@
 include_recipe "datashades::default"
 
 include_recipe "datashades::ckan-setup"
+
+extra_disk = "/mnt/local_data"
+if ::File.directory?(extra_disk) then
+    swap_file = "#{extra_disk}/swapfile_2g"
+    bash "Add swap disk" do
+        code <<-EOS
+            dd if=/dev/zero of=#{swap_file} bs=1024 count=2M
+            chmod 0600 #{swap_file}
+            mkswap #{swap_file}
+        EOS
+        not_if { ::File.exist?(swap_file) }
+    end
+
+    execute "Enable swap disk" do
+        command "swapon -s | grep '^#{swap_file} ' || swapon #{swap_file}"
+    end
+end

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -24,47 +24,10 @@ include_recipe "datashades::default-configure"
 
 service_name = 'solr'
 
-template "/usr/local/bin/solr-env.sh" do
-	source "solr-env.sh.erb"
-	owner "root"
-	group "root"
-	mode "0755"
-end
-
-cookbook_file "/usr/local/bin/solr-healthcheck.sh" do
-	source "solr-healthcheck.sh"
-	owner "root"
-	group "root"
-	mode "0755"
-end
-
-cookbook_file "/usr/local/bin/toggle-solr-healthcheck.sh" do
-	source "toggle-solr-healthcheck.sh"
-	owner "root"
-	group "root"
-	mode "0755"
-end
-
-cookbook_file "/usr/local/bin/pick-solr-master.sh" do
-	source "pick-solr-master.sh"
-	owner "root"
-	group "root"
-	mode "0755"
-end
-
-cookbook_file "/usr/local/bin/solr-sync.sh" do
-	source "solr-sync.sh"
-	owner "root"
-	group "root"
-	mode "0755"
-end
+# Add instance to pool
 
 file "/data/solr-healthcheck_#{node['datashades']['hostname']}" do
 	action :touch
-end
-
-cookbook_file "/etc/logrotate.d/solr" do
-	source "solr-logrotate"
 end
 
 cron "Solr health check" do
@@ -98,11 +61,4 @@ bash "Add #{service_name} DNS entry" do
 		alias="#{node['datashades']['app_id']}#{service_name}${server_id}.#{node['datashades']['tld']}"
 		echo "#{service_name}_${failover_type}=${alias}" >> /etc/hostnames
 	EOS
-end
-
-cookbook_file '/bin/updatedns' do
-	source 'updatedns'
-	owner 'root'
-	group 'root'
-	mode '0755'
 end

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -123,6 +123,56 @@ cookbook_file "/etc/supervisord.d/supervisor-solr.ini" do
     mode "0744"
 end
 
+# Create management scripts
+
+cookbook_file '/bin/updatedns' do
+	source 'updatedns'
+	owner 'root'
+	group 'root'
+	mode '0755'
+end
+
+template "/usr/local/bin/solr-env.sh" do
+	source "solr-env.sh.erb"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
+cookbook_file "/usr/local/bin/solr-healthcheck.sh" do
+	source "solr-healthcheck.sh"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
+cookbook_file "/usr/local/bin/toggle-solr-healthcheck.sh" do
+	source "toggle-solr-healthcheck.sh"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
+cookbook_file "/usr/local/bin/pick-solr-master.sh" do
+	source "pick-solr-master.sh"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
+cookbook_file "/usr/local/bin/solr-sync.sh" do
+	source "solr-sync.sh"
+	owner "root"
+	group "root"
+	mode "0755"
+end
+
+cookbook_file "/etc/logrotate.d/solr" do
+	source "solr-logrotate"
+end
+
+# Patch vulnerable Log4J
+
 log4j_version = '2.17.1'
 for jar_type in ['1.2-api', 'api', 'core', 'slf4j-impl'] do
     log4j_artefact = "log4j-#{jar_type}"
@@ -135,6 +185,8 @@ for jar_type in ['1.2-api', 'api', 'core', 'slf4j-impl'] do
     end
 end
 
+# move logs off root disk
+
 if extra_disk_present then
     real_data_dir = "#{extra_disk}/#{service_name}_data"
     real_log_dir = "#{extra_disk}/#{service_name}"
@@ -142,8 +194,6 @@ else
     real_data_dir = efs_data_dir
     real_log_dir = var_log_dir
 end
-
-# move logs off root disk
 
 datashades_move_and_link(var_log_dir) do
     target real_log_dir


### PR DESCRIPTION
'Configure' recipes should contain tasks that make an instance active, such as cron jobs and health check files. Other tasks go in setup/deploy.