### PR TITLE
[QOLDEV-833] only start Supervisor during 'configure' phase

### DIFF
--- a/recipes/ckanbatch-deploy.rb
+++ b/recipes/ckanbatch-deploy.rb
@@ -111,8 +111,3 @@ template "/usr/local/bin/ckan-monitor-job-queue.sh" do
     group 'root'
     mode '0755'
 end
-
-service "supervisord restart" do
-    service_name "supervisord"
-    action [:stop, :start]
-end

--- a/recipes/ckanweb-deploy.rb
+++ b/recipes/ckanweb-deploy.rb
@@ -129,8 +129,3 @@ template "#{nginx_config_file}" do
 end
 
 node.default['datashades']['auditd']['rules'].push("/etc/nginx/conf.d/#{node['datashades']['sitename']}-#{app['shortname']}.conf")
-
-service "supervisord restart" do
-	service_name "supervisord"
-	action [:stop, :start]
-end

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -110,11 +110,8 @@ end
 
 service "supervisord start" do
     service_name "supervisord"
-    action [:start]
-end
-
-execute "Update supervisor workers if needed" do
-    command "supervisorctl update"
+    supports restart: true
+    action [:restart]
 end
 
 # Re-enable and start in case it was stopped by previous recipe versions

--- a/recipes/default-configure.rb
+++ b/recipes/default-configure.rb
@@ -110,7 +110,7 @@ end
 
 service "supervisord start" do
     service_name "supervisord"
-    action [:enable,:start]
+    action [:start]
 end
 
 execute "Update supervisor workers if needed" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -211,9 +211,13 @@ if system('which systemctl')
                 WantedBy: 'multi-user.target'
             }
         })
-        action [:create, :enable]
+        action [:create, :enable, :stop]
     end
 else
+    service "supervisord" do
+        action [:enable]
+    end
+
     # Managed processes sometimes don't shut down properly on daemon stop,
     # leaving them 'orphaned' and resulting in duplicates.
     # Work around by issuing a stop command to the children first.

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -243,7 +243,12 @@ end
 service service_name do
     action [:stop]
 end
-execute "rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/" do
+bash "Copy latest index from EFS" do
+    code <<-EOS
+        rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/
+        LATEST_INDEX=`ls -dtr #{efs_data_dir}/data/#{core_name}/data/snapshot.* |tail -1`
+        rsync $LATEST_INDEX/ #{real_data_dir}/data/#{core_name}/data/index/
+    EOS
     only_if { ::File.directory? efs_data_dir }
 end
 

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -244,7 +244,6 @@ service service_name do
     action [:stop]
 end
 execute "rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/" do
-    user service_name
     only_if { ::File.directory? efs_data_dir }
 end
 

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -239,15 +239,13 @@ directory "#{efs_data_dir}/data/#{core_name}/data" do
     recursive true
 end
 
-# copy EFS contents if we need them, but don't alter them
-if not ::File.identical?(real_data_dir, var_data_dir) then
-    service service_name do
-        action [:stop]
-    end
-    execute "rsync -a #{efs_data_dir}/ #{real_data_dir}/" do
-        user service_name
-        only_if { ::File.directory? efs_data_dir }
-    end
+# copy latest EFS contents
+service service_name do
+    action [:stop]
+end
+execute "rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/" do
+    user service_name
+    only_if { ::File.directory? efs_data_dir }
 end
 
 datashades_move_and_link(var_data_dir) do

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -107,7 +107,7 @@ unless ::File.identical?(installed_solr_version, solr_path)
 
     execute "install #{service_name} #{solr_version}" do
         cwd "#{working_dir}/solr-#{solr_version}"
-        command "./bin/install_solr_service.sh #{Chef::Config[:file_cache_path]}/solr-#{solr_version}.zip -f"
+        command "./bin/install_solr_service.sh #{Chef::Config[:file_cache_path]}/solr-#{solr_version}.zip -f -n"
     end
 end
 
@@ -263,8 +263,3 @@ execute "Ensure directory ownership is correct" do
 end
 
 include_recipe "datashades::solr-deploycore"
-
-service "supervisord restart" do
-    service_name "supervisord"
-    action [:stop, :start]
-end


### PR DESCRIPTION
- Wait until instance is meant to be active before starting services. This will help us set up instances for warm-standby, or as templates for generating golden AMIs.