### PR TITLE
QOLDEV-892 fix VPC ID variable syntax

### DIFF
--- a/recipes/stackparams.rb
+++ b/recipes/stackparams.rb
@@ -59,8 +59,8 @@ node.default['datashades']['solr_app']['app_source']['url'] = `aws ssm get-param
 bash "Get VPC CIDR" do
 	user "root"
 	code <<-EOS
-		mac_id = `curl -H "X-aws-ec2-metadata-token: #{metadata_token}" http:/169.254.169.254/latest/meta-data/network/interfaces/macs`
-		vpc_id = `curl -H "X-aws-ec2-metadata-token: #{metadata_token}" http:/169.254.169.254/latest/meta-data/network/interfaces/macs/$mac_id/vpc-id`
+		mac_id=`curl -H "X-aws-ec2-metadata-token: #{metadata_token}" http:/169.254.169.254/latest/meta-data/network/interfaces/macs`
+		vpc_id=`curl -H "X-aws-ec2-metadata-token: #{metadata_token}" http:/169.254.169.254/latest/meta-data/network/interfaces/macs/$mac_id/vpc-id`
 		aws ec2 describe-vpcs --region "#{node['datashades']['region']}" --vpc-ids "$vpc_id" | jq '.Vpcs[].CidrBlock' | tr -d '"' > /etc/vpccidr
 	EOS
 end

--- a/recipes/stackparams.rb
+++ b/recipes/stackparams.rb
@@ -24,7 +24,7 @@
 #
 
 # Retrieve attributes from instance metadata
-metadata_token=`curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" http://169.254.169.254/latest/api/token`
+metadata_token=`curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 300" http://169.254.169.254/latest/api/token`
 node.default['datashades']['region'] = `curl -H "X-aws-ec2-metadata-token: #{metadata_token}" http:/169.254.169.254/latest/meta-data/placement/region`
 node.default['datashades']['instid'] = `curl -H "X-aws-ec2-metadata-token: #{metadata_token}" http:/169.254.169.254/latest/meta-data/instance-id`
 


### PR DESCRIPTION
Incorrect shell syntax was causing CIDR not to be populated.