### PR TITLE
QOLDEV-892 defer starting job workers until configure phase

### DIFF
--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -25,6 +25,18 @@ if not system('yum info supervisor')
     service "ckan-worker" do
         action [:enable, :start]
     end
+
+    bash "Enable extra job queues if available" do
+        code <<-EOS
+            UNITS="ckan-worker-priority ckan-worker-bulk ckan-worker-harvest-fetch ckan-worker-harvest-gather"
+            for UNIT_NAME in $UNITS; do
+                if (systemctl -a |grep "$UNIT_NAME"); then
+                    systemctl enable "$UNIT_NAME"
+                    systemctl start "$UNIT_NAME"
+                fi
+            done
+        EOS
+    end
 end
 
 # Run tracking update at 8:30am everywhere

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -274,7 +274,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create, :enable, :start]
+					action [:create]
 				end
 				systemd_unit "ckan-worker-harvest-gather.service" do
 					content({
@@ -293,7 +293,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create, :enable, :start]
+					action [:create]
 				end
 			end
 
@@ -394,7 +394,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create, :enable, :start]
+					action [:create]
 				end
 				systemd_unit "ckan-worker-priority.service" do
 					content({
@@ -413,7 +413,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create, :enable, :start]
+					action [:create]
 				end
 			end
 


### PR DESCRIPTION
- We don't want to start workers before their code is fully installed.