### PR TITLE
[QOLDEV-892] enable job workers on creation, just don't start them

### DIFF
--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -31,7 +31,6 @@ if not system('yum info supervisor')
             UNITS="ckan-worker-priority ckan-worker-bulk ckan-worker-harvest-fetch ckan-worker-harvest-gather"
             for UNIT_NAME in $UNITS; do
                 if (systemctl -a |grep "$UNIT_NAME"); then
-                    systemctl enable "$UNIT_NAME"
                     systemctl start "$UNIT_NAME"
                 fi
             done

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -274,7 +274,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create]
+					action [:create, :enable]
 				end
 				systemd_unit "ckan-worker-harvest-gather.service" do
 					content({
@@ -293,7 +293,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create]
+					action [:create, :enable]
 				end
 			end
 
@@ -394,7 +394,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create]
+					action [:create, :enable]
 				end
 				systemd_unit "ckan-worker-priority.service" do
 					content({
@@ -413,7 +413,7 @@ sorted_plugin_names.each do |plugin|
 							WantedBy: 'multi-user.target'
 						}
 					})
-					action [:create]
+					action [:create, :enable]
 				end
 			end
 


### PR DESCRIPTION
- We need to enable the worker units in order for systemctl to be aware of them