### PR TITLE
[QOLSVC-6955] revert to SMTP relay 1.3.1 due to missing provider problem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -159,8 +159,8 @@ directory "/usr/share/aws-smtp-relay" do
     action :create
 end
 
-cookbook_file "/usr/share/aws-smtp-relay/aws-smtp-relay-1.3.2-jar-with-dependencies.jar" do
-    source "aws-smtp-relay-1.3.2-jar-with-dependencies.jar"
+cookbook_file "/usr/share/aws-smtp-relay/aws-smtp-relay-1.3.1-jar-with-dependencies.jar" do
+    source "aws-smtp-relay-1.3.1-jar-with-dependencies.jar"
 end
 
 template "/etc/init.d/aws-smtp-relay" do

--- a/templates/default/aws-smtp-relay.erb
+++ b/templates/default/aws-smtp-relay.erb
@@ -19,7 +19,7 @@ function start {
 
   # Listen on a secondary loopback address so we can coexist with the default MTA.
   # Taking over entirely is a bad idea because we get lots of undeliverable system emails.
-  java -jar /usr/share/aws-smtp-relay/aws-smtp-relay-1.3.2-jar-with-dependencies.jar -b 127.0.1.1 -p 25 -ssm -ssmP /config/CKAN/<%= node['datashades']['version'] %>/smtpRelay &
+  java -jar /usr/share/aws-smtp-relay/aws-smtp-relay-1.3.1-jar-with-dependencies.jar -b 127.0.1.1 -p 25 -ssm -ssmP /config/CKAN/<%= node['datashades']['version'] %>/smtpRelay &
   echo $! > $PIDFILE
 }
 


### PR DESCRIPTION
Version 1.3.2 encountered protocol errors.