### PR TITLE
QOLDEV-863 Fix solr HA

### DIFF
--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -62,8 +62,8 @@ function import_snapshot () {
       sudo service solr stop
       sudo -u solr mkdir $LOCAL_DIR/index
       rm $LOCAL_DIR/index/* && sudo -u solr tar -xzf "$SYNC_SNAPSHOT" -C $LOCAL_DIR/index || exit 1
-      sudo service solr start
-      return 1
+      sudo systemctl start solr
+      return 0
     else
       sleep 5
     fi

--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -60,6 +60,13 @@ file "/etc/cron.daily/ckan-revision-archival" do
     group "root"
 end
 
+file "/etc/cron.daily/prune-health-checks" do
+    content "/usr/local/bin/pick-job-server.sh && find /data -maxdepth 1 -name '*-healthcheck_*' -mmin '+60' -execdir rm '{}' ';' >/dev/null 2>&1\n"
+    mode "0755"
+    owner "root"
+    group "root"
+end
+
 file "/etc/cron.d/ckan-worker" do
     content "*/5 * * * * root /usr/local/bin/pick-job-server.sh && /usr/local/bin/ckan-monitor-job-queue.sh >/dev/null 2>&1\n"
     mode '0644'

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -267,10 +267,15 @@ service service_name do
     action [:stop]
 end
 bash "Copy latest index from EFS" do
+    user account_name
     code <<-EOS
         rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/
-        LATEST_INDEX=`ls -dtr #{efs_data_dir}/data/#{core_name}/data/snapshot.* |tail -1`
-        rsync $LATEST_INDEX/ #{real_data_dir}/data/#{core_name}/data/index/
+        CORE_DATA="#{real_data_dir}/data/#{core_name}/data"
+        LATEST_INDEX=`ls -dtr $CORE_DATA/snapshot.* |tail -1`
+        if (echo "$LATEST_INDEX" |grep "[.]tgz$" >/dev/null 2>&1); then
+            mkdir -p "$CORE_DATA/index"
+            rm -f $CORE_DATA/index/*; tar -xzf "$LATEST_INDEX" -C $CORE_DATA/index
+        fi
     EOS
     only_if { ::File.directory? efs_data_dir }
 end


### PR DESCRIPTION
- Import backups into secondary server(s) by stopping the server and wholesale replacing the index, rather than trying to dynamically import.
- Export backups as archives rather than exploded directories.

TODO Use S3 to pass backups, rather than EFS.