### PR TITLE
[QOLDEV-863] ignore malformed Solr index archives

### DIFF
--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -58,9 +58,13 @@ function export_snapshot () {
 function import_snapshot () {
   # Give the master time to update the sync copy
   for i in $(eval echo "{1..40}"); do
-    if [ -f "$SYNC_SNAPSHOT" ]; then
+    # If the snapshot is a readable tar archive, then import it.
+    # Ignore it if it's missing or malformed.
+    if (tar tzf "$SYNC_SNAPSHOT" >/dev/null 2>&1); then
       sudo service solr stop
       sudo -u solr mkdir $LOCAL_DIR/index
+      # Wipe old index files if any, and unpack the archived index.
+      # Fail the whole import if we can't.
       rm -f $LOCAL_DIR/index/* && sudo -u solr tar -xzf "$SYNC_SNAPSHOT" -C $LOCAL_DIR/index || exit 1
       sudo systemctl start solr
       return 0

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -272,8 +272,11 @@ bash "Copy latest index from EFS" do
         rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/
         CORE_DATA="#{real_data_dir}/data/#{core_name}/data"
         LATEST_INDEX=`ls -dtr $CORE_DATA/snapshot.* |tail -1`
-        if (echo "$LATEST_INDEX" |grep "[.]tgz$" >/dev/null 2>&1) && (tar tzf "$LATEST_INDEX" >/dev/null); then
+        # If the latest snapshot is a readable tar archive, then import it.
+        # If not, then it's either a directory (obsolete) or malformed, so ignore it.
+        if (tar tzf "$LATEST_INDEX" >/dev/null 2>&1); then
             mkdir -p "$CORE_DATA/index"
+            # wipe old index files if any, and unpack the archived index
             rm -f $CORE_DATA/index/*; tar -xzf "$LATEST_INDEX" -C $CORE_DATA/index
         fi
     EOS

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -272,7 +272,7 @@ bash "Copy latest index from EFS" do
         rsync -a --delete #{efs_data_dir}/ #{real_data_dir}/
         CORE_DATA="#{real_data_dir}/data/#{core_name}/data"
         LATEST_INDEX=`ls -dtr $CORE_DATA/snapshot.* |tail -1`
-        if (echo "$LATEST_INDEX" |grep "[.]tgz$" >/dev/null 2>&1); then
+        if (echo "$LATEST_INDEX" |grep "[.]tgz$" >/dev/null 2>&1) && (tar tzf "$LATEST_INDEX" >/dev/null); then
             mkdir -p "$CORE_DATA/index"
             rm -f $CORE_DATA/index/*; tar -xzf "$LATEST_INDEX" -C $CORE_DATA/index
         fi


### PR DESCRIPTION
- Skip importing index archive if tar can't process it