### PR TITLE
[QOLDEV-933] import PURL endpoint from SSM Parameter Store

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -134,6 +134,8 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = <%= node['datashades']['redis']['hostname'] %>
 ckan.harvest.mq.port = <%= node['datashades']['redis']['port'] %>
 
+urlm.app_path = {ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/purl_endpoint}
+
 ## QA
 qa.resource_format_openness_scores_json = <%= @src_dir %>/ckanext-data-qld/ckanext/data_qld/resource_format_openness_scores.json
 

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -135,7 +135,7 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = <%= node['datashades']['redis']['hostname'] %>
 ckan.harvest.mq.port = <%= node['datashades']['redis']['port'] %>
 
-urlm.app_path = {ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/purl_endpoint}
+urlm.app_path = ${ssm:/config/CKAN/<%= node['datashades']['version'] %>/app/<%= node['datashades']['app_id'] %>/purl_endpoint}
 
 ## QA
 qa.resource_format_openness_scores_json = <%= @src_dir %>/ckanext-data-qld/ckanext/data_qld/resource_format_openness_scores.json

--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -97,6 +97,7 @@ ckan.auth.create_user_via_api = <%= node['datashades']['ckan_web']['auth']['crea
 ckan.auth.create_user_via_web = <%= node['datashades']['ckan_web']['auth']['create_user_via_web'] %>
 ckan.auth.roles_that_cascade_to_sub_groups = <%= node['datashades']['ckan_web']['auth']['roles_that_cascade_to_sub_groups'] %>
 ckan.auth.public_user_details = False
+ckan.auth.reveal_private_datasets = True
 
 ## QGOV Settings
 


### PR DESCRIPTION
- ckanext-qgov already looks for the `urlm.app_path` property, we just haven't been setting it until now.