### PR TITLE
[QOLSVC-7726] fix Archiver user agent string to comply with RFC 9110

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -281,7 +281,7 @@ ckanext-archiver.archive_dir = /var/shared_content/<%= @app_name %>/resource_cac
 #the plan; drop this for patten /dataset/{id}/resource/{resource_id}/archive/{filename}
 ckanext-archiver.cache_url_root = /resource_cache
 ckanext-archiver.max_content_length = 250000000
-ckanext-archiver.user_agent_string = "CKAN archiver https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>"
+ckanext-archiver.user_agent_string = CKAN archiver (https://<%= @app_url %><% node['datashades']['ckan_web']['endpoint'] %>)
 ckanext-archiver.verify_https = True
 
 ## Cache


### PR DESCRIPTION
- Don't wrap the whole string in double quotes. Comments can be quoted or bracketed.