### PR TITLE
[QOLDEV-933] return 404 on unauthorised requests for deleted datasets

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -98,6 +98,7 @@ ckan.auth.create_user_via_web = <%= node['datashades']['ckan_web']['auth']['crea
 ckan.auth.roles_that_cascade_to_sub_groups = <%= node['datashades']['ckan_web']['auth']['roles_that_cascade_to_sub_groups'] %>
 ckan.auth.public_user_details = False
 ckan.auth.reveal_private_datasets = True
+ckan.auth.reveal_deleted_datasets = False
 
 ## QGOV Settings
 


### PR DESCRIPTION
- Private datasets can redirect to login, but deleted ones should give 404 so they can participate in PURL