### PR TITLE
[QOLSVC-5425] refresh reports each day

### DIFF
--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -127,6 +127,7 @@ end
 #
 harvester_data_qld_geoscience_present = false
 archiver_present = false
+report_present = false
 resource_visibility_present = false
 harvest_present = false
 csrf_present = false
@@ -467,6 +468,17 @@ sorted_plugin_names.each do |plugin|
 			user "#{account_name}"
 			command "PASTER_PLUGIN=ckanext-report #{ckan_cli} report initdb || echo 'Ignoring expected error'"
 		end
+
+		if batchnode
+			report_present = true
+
+			file "/etc/cron.daily/refresh_reports" do
+				content "/usr/local/bin/pick-job-server.sh && #{ckan_cli} report generate >> /var/log/ckan/ckan-report-run.log\n"
+				mode '0755'
+				owner "root"
+				group "root"
+			end
+		end
 	end
 
 	if "#{pluginname}".eql? 'datarequests'
@@ -547,6 +559,12 @@ end
 if not resource_visibility_present then
 	execute "Clean Resource Visibility cron" do
 		command "rm -f /etc/cron.d/ckan-dataset-resource-visibility-notify-privacy-assessments*"
+	end
+end
+
+if not report_present then
+	execute "Clean Report cron" do
+		command "rm -f /etc/cron.daily/refresh_reports*"
 	end
 end
 


### PR DESCRIPTION
Reports are cached for several days, but once they expire, generating fresh ones (when the URL is visited) can take so long that errors are returned. Implementing a daily cron job should resolve this, keeping reports relatively fresh without end-user interaction.