### PR TITLE
[QOLSVC-10616] move datastore forward in plugin order

### DIFF
--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -83,7 +83,8 @@ extextras =
 #
 extordering =
 {
-	'data_qld data_qld_google_analytics' => 1,
+	'datastore' => 1,
+	'data_qld data_qld_google_analytics' => 3,
 	'dcat structured_data' => 5,
 	'validation' => 10,
 	'resource_type_validation' => 20,
@@ -101,7 +102,6 @@ extordering =
 	'odi_certificates' => 60,
 	'resource_visibility' => 70,
 	'ssm_config' => 80,
-	'datastore' => 80,
 	'xloader' => 85,
 	'clamav' => 90,
 	's3filestore' => 95


### PR DESCRIPTION
Ensure the Datastore plugin has the chance to add the Data API button. Previously our theme was intercepting the template first and therefore had to re-add the button manually.