### PR TITLE
[QOLSVC-10984] add GA4 collection URL to config

### DIFF
--- a/templates/default/ckan_properties.ini.erb
+++ b/templates/default/ckan_properties.ini.erb
@@ -146,6 +146,7 @@ googleanalytics.domain = auto
 
 ckan.data_qld_googleanalytics.id = <%= node['datashades']['ckan_web']['google']['analytics_id'] %>
 ckan.data_qld_googleanalytics.collection_url = http://www.google-analytics.com/collect
+ckanext.data_qld_googleanalytics.ga4_collection_url = https://www.google-analytics.com/mp/collect?api_secret={{ssm:/config/CKAN/<%= node['datashades']['version'] %>/common/Ga4ApiSecret}}&measurement_id={{ssm:/config/CKAN/<%= node['datashades']['version'] %>/common/Ga4MeasurementId}}
 
 ## ckanext-data-qld Reporting
 ckan.reporting.datarequest_open_max_days = 60


### PR DESCRIPTION
- Retrieve API Secret and Measurement ID from SSM Parameter Store. These will need to be manually added to the store.