### PR TITLE
Develop to master - fix plugin ordering

### DIFF
--- a/files/default/solr-import-backup.sh
+++ b/files/default/solr-import-backup.sh
@@ -11,7 +11,7 @@ SOLR_DIR=/var/solr/data/$CORE_NAME/data
 ARCHIVE_NAME=$1
 
 sudo systemctl stop solr
-sudo -u solr rm $SOLR_DIR/index.properties
+sudo -u solr rm -f $SOLR_DIR/index.properties
 sudo -u solr mkdir $SOLR_DIR/index
 sudo -u solr tar -C $SOLR_DIR/index -xvzf $ARCHIVE_NAME
 sudo systemctl start solr

--- a/files/default/solr-restore-from-backup.sh
+++ b/files/default/solr-restore-from-backup.sh
@@ -33,6 +33,6 @@ sh `dirname $0`/solr-healthcheck.sh
 sh `dirname $0`/solr-sync.sh
 
 # Allow other servers, if any, to re-enter the pool
-if `ls /tmp/solr-healthcheck_*`; then
+if (ls /tmp/solr-healthcheck_*); then
     mv /tmp/solr-healthcheck_* /data/;
 fi

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -125,6 +125,26 @@ bash "Install NPM and NodeJS" do
 	EOS
 end
 
+# Enable DataStore extension if desired
+if ["yes", "y", "true", "t"].include? node['datashades']['ckan_web']['dsenable'].downcase then
+	bash "Enable DataStore-related extensions" do
+		user "ckan"
+		cwd "#{config_dir}"
+		code <<-EOS
+			if [ -z  "$(grep 'ckan.plugins.*datastore' #{config_file})" ]; then
+				sed -i "/^ckan.plugins/ s/$/ datastore/" #{config_file}
+			fi
+		EOS
+	end
+
+	cookbook_file "#{config_dir}/allowed_functions.txt" do
+		source 'allowed_functions.txt'
+		owner "#{account_name}"
+		group "#{account_name}"
+		mode "0755"
+	end
+end
+
 # Do the actual extension installation using pip
 #
 harvester_data_qld_geoscience_present = false
@@ -613,26 +633,6 @@ end
 #         EOS
 #     end
 # end
-
-# Enable DataStore extension if desired
-if ["yes", "y", "true", "t"].include? node['datashades']['ckan_web']['dsenable'].downcase then
-	bash "Enable DataStore-related extensions" do
-		user "ckan"
-		cwd "#{config_dir}"
-		code <<-EOS
-			if [ -z  "$(grep 'ckan.plugins.*datastore' #{config_file})" ]; then
-				sed -i "/^ckan.plugins/ s/$/ datastore/" #{config_file}
-			fi
-		EOS
-	end
-
-	cookbook_file "#{config_dir}/allowed_functions.txt" do
-		source 'allowed_functions.txt'
-		owner "#{account_name}"
-		group "#{account_name}"
-		mode "0755"
-	end
-end
 
 bash "Enable Activity Streams extension on CKAN 2.10+" do
 	user "#{account_name}"


### PR DESCRIPTION
Add datastore plugin before ordered plugins, so that it can be properly accounted for in applying ordering.

This has been successfully tested on dev.data.qld.gov.au