### PR TITLE
QOLSVC-11279 work around threading-related errors

### DIFF
--- a/files/default/ckan-uwsgi.ini
+++ b/files/default/ckan-uwsgi.ini
@@ -33,7 +33,7 @@ auto-procname   = true ; Give nice name
 ; See https://github.com/ckan/ckan/issues/5933
 
 cheaper-algo        = busyness
-processes           = 8                 ; Maximum number of workers allowed
+processes           = 4                 ; Maximum number of workers allowed
 cheaper             = 2                 ; Minimum number of workers allowed
 cheaper-initial     = 2                 ; Workers created at startup
 cheaper-overload    = 1                 ; Length of a cycle in seconds

--- a/files/default/ckan-uwsgi.ini
+++ b/files/default/ckan-uwsgi.ini
@@ -24,7 +24,7 @@ lazy-apps       = true
 log-format      =  %(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"
 
 enable-threads  = true
-threads         = 16                  ; Threads per worker/process
+threads         = 1                  ; Threads per worker/process
 py-call-osafterfork = true ; Ensure os kill signals propagate to sub threads.
 auto-procname   = true ; Give nice name
 
@@ -33,7 +33,7 @@ auto-procname   = true ; Give nice name
 ; See https://github.com/ckan/ckan/issues/5933
 
 cheaper-algo        = busyness
-processes           = 4                 ; Maximum number of workers allowed
+processes           = 8                 ; Maximum number of workers allowed
 cheaper             = 2                 ; Minimum number of workers allowed
 cheaper-initial     = 2                 ; Workers created at startup
 cheaper-overload    = 1                 ; Length of a cycle in seconds

--- a/recipes/ckanweb-deploy-exts.rb
+++ b/recipes/ckanweb-deploy-exts.rb
@@ -412,8 +412,8 @@ sorted_plugin_names.each do |plugin|
 					freshclam
 					# Default clamd config doesn't enable any socket and will therefore fail
 					CLAMD_CONFIG=$(ls /etc/clamd.d/*.conf |head 1)
-					sed -i 's|^#LocalSocket |LocalSocket /var/run/clamd.scan/clamd.ctl|g' $CLAMD_CONFIG
-					sed -i 's|^#LocalSocketMode |LocalSocketMode 660|g' $CLAMD_CONFIG
+					sed -i 's|^#LocalSocket .*|LocalSocket /var/run/clamd.scan/clamd.ctl|g' $CLAMD_CONFIG
+					sed -i 's|^#LocalSocketMode .*|LocalSocketMode 660|g' $CLAMD_CONFIG
 
 					systemctl enable clamav-freshclam
 					systemctl enable clamd@scan


### PR DESCRIPTION
Use multiple processes instead of multiple threads to avoid threading-related issues.