### PR TITLE
[QOLSVC-10262] make Solr sync rely on S3 instead of EFS

### DIFF
--- a/files/default/solr-import-backup.sh
+++ b/files/default/solr-import-backup.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-if [ "$#" -lt 1 ]; then
+if [ "$(id -ru)" != "0" ] || [ "$#" -lt 1 ]; then
     echo "Usage: $0 <archive path>" >&2
+    echo "$0 must be run as root"
     exit 1
 fi
 
@@ -10,8 +11,8 @@ fi
 SOLR_DIR=/var/solr/data/$CORE_NAME/data
 ARCHIVE_NAME=$1
 
-sudo systemctl stop solr
+systemctl stop solr
 sudo -u solr rm -f $SOLR_DIR/index.properties
 sudo -u solr mkdir $SOLR_DIR/index
 sudo -u solr tar -C $SOLR_DIR/index -xvzf $ARCHIVE_NAME
-sudo systemctl start solr
+systemctl start solr

--- a/files/default/solr-import-backup.sh
+++ b/files/default/solr-import-backup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Specify a (local) path to a Solr index snapshot archive.
+# This script will import the index into the local Solr instance.
+# This will cause a brief outage, as Solr will be stopped
+# and its index overwritten with the snapshot.
+# No attempt is made to interact with other Solr instances.
+
 if [ "$(whoami)" != "root" ] || [ "$#" -lt 1 ]; then
     echo "Usage: $0 <archive path>" >&2
     echo "$0 must be run as root"
@@ -11,6 +17,7 @@ fi
 SOLR_DIR=/var/solr/data/$CORE_NAME/data
 ARCHIVE_NAME=$1
 
+echo "Importing Solr index from ${ARCHIVE_NAME}..."
 systemctl stop solr
 sudo -u solr rm -f $SOLR_DIR/index.properties
 sudo -u solr mkdir $SOLR_DIR/index

--- a/files/default/solr-import-backup.sh
+++ b/files/default/solr-import-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(id -ru)" != "0" ] || [ "$#" -lt 1 ]; then
+if [ "$(whoami)" != "root" ] || [ "$#" -lt 1 ]; then
     echo "Usage: $0 <archive path>" >&2
     echo "$0 must be run as root"
     exit 1

--- a/files/default/solr-restore-from-backup.sh
+++ b/files/default/solr-restore-from-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(id -ru)" != "0" ]; then
+if [ "$(whoami)" != "root" ]; then
     echo "$0 must be run as root"
     exit 1
 fi

--- a/files/default/solr-restore-from-backup.sh
+++ b/files/default/solr-restore-from-backup.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$(id -ru)" != "0" ]; then
+    echo "$0 must be run as root"
+    exit 1
+fi
+
 . `dirname $0`/solr-env.sh
 
 LATEST_BACKUP=$(aws s3 ls "s3://$BUCKET/solr_backup/$CORE_NAME/" |awk '{print $4}' |sort |tail -1)
@@ -33,6 +38,6 @@ sh `dirname $0`/solr-healthcheck.sh
 sh `dirname $0`/solr-sync.sh
 
 # Allow other servers, if any, to re-enter the pool
-if (ls /tmp/solr-healthcheck_*); then
+if (ls /tmp/ | grep 'solr-healthcheck_'); then
     mv /tmp/solr-healthcheck_* /data/;
 fi

--- a/files/default/solr-restore-from-backup.sh
+++ b/files/default/solr-restore-from-backup.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 
+# This script retrieves the latest backed-up Solr index from S3,
+# and applies it to the current Solr instance.
+# This will cause a brief outage, as Solr will be stopped
+# and its index overwritten with the snapshot.
+
 if [ "$(whoami)" != "root" ]; then
     echo "$0 must be run as root"
     exit 1
+fi
+
+if ! (grep 'solr_master' /etc/hostnames); then
+    echo "WARNING: This server is not the master instance, restored index may not take effect!"
 fi
 
 . `dirname $0`/solr-env.sh
@@ -13,31 +22,8 @@ if [ "$LATEST_BACKUP" = "" ]; then
     exit 1
 fi
 
-echo "Restoring from backup ${LATEST_BACKUP}..."
-# Disable all servers
-for heartbeat_file in `ls /data/solr-healthcheck_*`; do
-  echo "" > $heartbeat_file
-  mv $heartbeat_file /tmp/
-done
-
-# Override regular snapshots with one from S3
-sudo -u solr aws s3 cp "s3://$BUCKET/solr_backup/$CORE_NAME/$LATEST_BACKUP" $SYNC_DIR/override-snapshot.$CORE_NAME.tgz || exit 1
+# Retrieve snapshot from S3
+sudo -u solr aws s3 cp "s3://$BUCKET/solr_backup/$CORE_NAME/$LATEST_BACKUP" $LOCAL_DIR/override-snapshot.$CORE_NAME.tgz || exit 1
 
 # Import index into current server
 sh `dirname $0`/solr-import-backup.sh $SYNC_DIR/override-snapshot.$CORE_NAME.tgz
-
-# Make this server the master
-mv /tmp/solr-healthcheck_${opsworks_hostname} /data/
-
-# Wait for Solr to start
-for i in $(eval echo "{1..6}"); do
-    curl -I --connect-timeout 5 "$PING_URL" 2>/dev/null |grep '200 OK' && break
-    sleep 5
-done
-sh `dirname $0`/solr-healthcheck.sh
-sh `dirname $0`/solr-sync.sh
-
-# Allow other servers, if any, to re-enter the pool
-if (ls /tmp/ | grep 'solr-healthcheck_'); then
-    mv /tmp/solr-healthcheck_* /data/;
-fi

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(id -ru)" != "0" ]; then
+if [ "$(whoami)" != "root" ]; then
     echo "$0 must be run as root"
     exit 1
 fi

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
+if [ "$(id -ru)" != "0" ]; then
+    echo "$0 must be run as root"
+    exit 1
+fi
+
 . `dirname $0`/solr-env.sh
 
 BACKUP_NAME="$CORE_NAME-$(date +'%Y-%m-%dT%H:%M')"
 SNAPSHOT_NAME="snapshot.$BACKUP_NAME"
 LOCAL_SNAPSHOT="$LOCAL_DIR/$SNAPSHOT_NAME"
-SYNC_SNAPSHOT="$SYNC_DIR/${SNAPSHOT_NAME}.tgz"
-OVERRIDE_SNAPSHOT="$SYNC_DIR/override-snapshot.$CORE_NAME.tgz"
+SYNC_SNAPSHOT="${LOCAL_SNAPSHOT}.tgz"
 MINUTE=$(date +%M)
 
 function set_dns_primary () {
@@ -54,32 +58,6 @@ function export_snapshot () {
   sh -c "$LUCENE_CHECK $LOCAL_SNAPSHOT && sudo -u solr tar --force-local --exclude=write.lock -czf $SYNC_SNAPSHOT -C $LOCAL_SNAPSHOT ." || return 1
 }
 
-function import_snapshot () {
-  if [ -e "$OVERRIDE_SNAPSHOT" ]; then
-    SYNC_SNAPSHOT="$OVERRIDE_SNAPSHOT"
-  fi
-  # Give the master time to update the sync copy
-  for i in $(eval echo "{1..40}"); do
-    # If the snapshot is a readable tar archive, then import it.
-    # Ignore it if it's missing or malformed.
-    if (tar tzf "$SYNC_SNAPSHOT" >/dev/null 2>&1); then
-      sudo service solr stop
-      sudo -u solr mkdir $DATA_DIR/index
-      # Wipe old index files if any, and unpack the archived index.
-      # Fail the whole import if we can't.
-      rm -f $DATA_DIR/index/* && sudo -u solr tar -xzf "$SYNC_SNAPSHOT" -C $DATA_DIR/index || exit 1
-      sudo systemctl start solr
-      rm -f $STARTUP_FILE
-      return 0
-    else
-      sleep 5
-    fi
-  done
-  rm -f $STARTUP_FILE
-  echo "Snapshot did not become available for import: $SYNC_SNAPSHOT"
-  return 1
-}
-
 # we can't perform any replication operations if Solr is stopped
 if ! (curl -I --connect-timeout 5 "$PING_URL" 2>/dev/null |grep '200 OK' > /dev/null); then
   set_dns_primary false
@@ -97,10 +75,6 @@ if (/usr/local/bin/pick-solr-master.sh); then
   for old_snapshot in $(ls -d $SYNC_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME"); do
     sudo -u solr rm -r "$old_snapshot"
   done
-  # Remove override snapshot once all servers have consumed it
-  if ! (ls /data/solr-healthcheck-*.start); then
-    rm -f $OVERRIDE_SNAPSHOT
-  fi
   # Drop this server from being master if export failed
   if [ "$EXPORT_STATUS" != "0" ]; then
     if [ "$EXPORT_STATUS" != "2" ]; then
@@ -117,7 +91,7 @@ if (/usr/local/bin/pick-solr-master.sh); then
 else
   # make traffic come to this instance only as a backup option
   set_dns_primary false
-  import_snapshot
+  sudo /usr/local/bin/solr-restore-from-backup.sh
 fi
 OLD_SNAPSHOTS=$(ls -d $LOCAL_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME")
 if [ "$OLD_SNAPSHOTS" != "" ]; then

--- a/files/default/solr-sync.sh
+++ b/files/default/solr-sync.sh
@@ -71,10 +71,6 @@ if (/usr/local/bin/pick-solr-master.sh); then
 
   # Export a snapshot of the index
   export_snapshot; EXPORT_STATUS=$?
-  # Remove old snapshots
-  for old_snapshot in $(ls -d $SYNC_DIR/snapshot.$CORE_NAME-* |grep -v "$SNAPSHOT_NAME"); do
-    sudo -u solr rm -r "$old_snapshot"
-  done
   # Drop this server from being master if export failed
   if [ "$EXPORT_STATUS" != "0" ]; then
     if [ "$EXPORT_STATUS" != "2" ]; then

--- a/recipes/ckanbatch-configure.rb
+++ b/recipes/ckanbatch-configure.rb
@@ -74,7 +74,7 @@ file "/etc/cron.daily/prune-health-checks" do
     group "root"
 end
 
-file "/etc/cron.daily/solr-reindex" do
+file "/etc/cron.hourly/solr-reindex" do
     content "/usr/local/bin/pick-job-server.sh && #{ckan_cli} search-index rebuild -ieo >/dev/null 2>&1\n"
     mode "0755"
     owner "root"

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -45,7 +45,7 @@ end
 
 # synchronise Solr cores via EFS
 file "/etc/cron.d/solr-sync" do
-	content "*/5 * * * * root /usr/local/bin/solr-sync.sh >> /var/log/solr/solr-sync.cron.log 2>&1\n"
+	content "*/20 * * * * root /usr/local/bin/solr-sync.sh >> /var/log/solr/solr-sync.cron.log 2>&1\n"
 	mode "0644"
 end
 

--- a/recipes/solr-configure.rb
+++ b/recipes/solr-configure.rb
@@ -49,28 +49,12 @@ file "/etc/cron.d/solr-sync" do
 	mode "0644"
 end
 
-# copy latest EFS contents
-service "Stop Solr if needed to load latest index" do
-	service_name service_name
-	action [:stop]
-end
-bash "Copy latest index from EFS" do
+# copy latest exported snapshot
+bash "Copy latest index from export" do
 	user service_name
 	code <<-EOS
-		rsync -a --delete #{efs_data_dir}/ /var/#{service_name}
-		CORE_DATA="/var/#{service_name}/data/#{core_name}/data"
-		LATEST_INDEX=`ls -dtr $CORE_DATA/snapshot.* |tail -1`
-		# If the latest snapshot is a readable tar archive, then import it.
-		# If not, then it's either a directory (obsolete) or malformed, so ignore it.
-		if (tar tzf "$LATEST_INDEX" >/dev/null 2>&1); then
-			mkdir -p "$CORE_DATA/index"
-			# remove the index.properties file so default index config is used
-			rm -f $CORE_DATA/index.properties
-			# wipe old index files if any, and unpack the archived index
-			rm -f $CORE_DATA/index/*; tar -xzf "$LATEST_INDEX" -C $CORE_DATA/index
-		fi
+		/usr/local/bin/solr-restore-from-backup.sh || echo "WARNING: Solr index could not be loaded from S3"
 	EOS
-	only_if { ::File.directory? efs_data_dir }
 end
 
 # Add DNS entry for service host

--- a/recipes/solr-deploy.rb
+++ b/recipes/solr-deploy.rb
@@ -66,6 +66,7 @@ solr_path = "/opt/solr"
 installed_solr_version = "#{solr_path}-#{solr_version}"
 solr_environment_file = "/etc/default/solr.in.sh"
 
+# run Solr install if we're not already using the target version
 unless ::File.identical?(installed_solr_version, solr_path)
     solr_artefact = "#{Chef::Config[:file_cache_path]}/solr-#{solr_version}.zip"
     if extra_disk_present then


### PR DESCRIPTION
- Sync secondary servers from hourly S3 backup instead of every 5 minutes via EFS
- Run incremental rebuild hourly to fix any shortfall