### PR TITLE
[QOLSVC-10262] update primary vs secondary Solr servers during health check

### DIFF
--- a/files/default/solr-healthcheck.sh
+++ b/files/default/solr-healthcheck.sh
@@ -11,6 +11,15 @@ if ! [ -e "$HEARTBEAT_FILE" ]; then
   exit 0
 fi
 
+function set_dns_primary () {
+  if [ "$1" = "true" ]; then
+    sed -i 's/^solr_slave=/solr_master=/' /etc/hostnames
+  else
+    sed -i 's/^solr_master=/solr_slave=/' /etc/hostnames
+  fi
+  updatedns &
+}
+
 is_ping_healthy () {
   (curl -I --connect-timeout 5 "$PING_URL" 2>/dev/null |grep '200 OK' > /dev/null) || return 1
 }
@@ -30,4 +39,10 @@ if [ "$IS_HEALTHY" = "0" ]; then
   rm -f $STARTUP_FILE
 else
   touch $STARTUP_FILE
+fi
+
+if (/usr/local/bin/pick-solr-master.sh); then
+  set_dns_primary true
+else
+  set_dns_primary false
 fi


### PR DESCRIPTION
Setting the primary server affects traffic, not just replication, so keep it up to date every minute.