### PR TITLE
Develop to master

### DIFF
--- a/files/default/allowed_functions.txt
+++ b/files/default/allowed_functions.txt
@@ -265,7 +265,6 @@ ts_delete
 ts_filter
 ts_headline
 ts_rank
-ts_rewrite
 tsvector_to_array
 unnest
 upper

--- a/recipes/ckan-deploy.rb
+++ b/recipes/ckan-deploy.rb
@@ -80,7 +80,7 @@ log "#{DateTime.now}: Installing pinned dependencies for CKAN"
 execute "Pin dependency versions" do
 	user service_name
 	group service_name
-	command "#{pip} install 'setuptools>=44.1.0,<71' 'pyOpenSSL>=23.0.0'"
+	command "#{pip} install 'setuptools>=44.1.0,<71' 'pyOpenSSL>=23.0.0' 'pyld==2.0.*'"
 end
 
 log "#{DateTime.now}: Installing CKAN source"


### PR DESCRIPTION
- Drop unwanted SQL function
- Pin `pyld` to version 2.x to retain Python 3.9 support