### PR TITLE
[QOLDEV-1884] update to Python 3.11

### DIFF
--- a/attributes/ckan.rb
+++ b/attributes/ckan.rb
@@ -22,7 +22,7 @@
 #
 
 default['datashades']['ckan_web']['endpoint'] = '/'
-default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'libxslt', 'libxslt-devel', 'gcc', 'gcc-c++', 'make', 'python3-devel', 'xalan-j2', 'unzip', 'squid']
+default['datashades']['ckan_web']['packages'] = ['xml-commons', 'git', 'libxslt', 'libxslt-devel', 'libxml2', 'libxml2-devel', 'libxslt', 'libxslt-devel', 'gcc', 'gcc-c++', 'make', 'python3.11-devel', 'xalan-j2', 'unzip', 'squid']
 default['datashades']['ckan_web']['alternative_packages'] = [
     ['postgresql', 'postgresql15'],
     ['postgresql-devel', 'postgresql15-server-devel'],

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,7 @@ default['datashades']['sitename'] = 'ckan'
 
 default['datashades']['backup']['retention'] = '30'
 
-default['datashades']['core']['packages'] = ['nfs-utils', 'clamav', 'gcc', 'jq', 'perl-Switch', 'perl-DateTime', 'perl-Sys-Syslog', 'perl-LWP-Protocol-https', 'perl-Digest-SHA', 'python3-pip', 'git', 'telnet', 'cronie']
+default['datashades']['core']['packages'] = ['nfs-utils', 'clamav', 'gcc', 'jq', 'perl-Switch', 'perl-DateTime', 'perl-Sys-Syslog', 'perl-LWP-Protocol-https', 'perl-Digest-SHA', 'python3.11-pip', 'git', 'telnet', 'cronie']
 default['datashades']['core']['alternative_packages'] = [
     ['postfix', 'sendmail'],
     ['yum-cron', 'dnf-automatic'],

--- a/recipes/ckan-setup.rb
+++ b/recipes/ckan-setup.rb
@@ -115,7 +115,7 @@ end
 bash "Create CKAN Default Virtual Environment" do
 	code <<-EOS
 		PATH="$PATH:/usr/local/bin"
-		virtualenv #{real_virtualenv_dir}
+		python3.11 -m venv #{real_virtualenv_dir}
 		chown -R #{service_name}:#{service_name} #{real_virtualenv_dir}
 	EOS
 	not_if { ::File.directory? "#{real_virtualenv_dir}/bin" }


### PR DESCRIPTION
CKAN 2.11.5 depends on at least Python 3.10. Amazon Linux 2023 does not offer Python 3.10, only 3.11, but CKAN core developers [have confirmed](https://github.com/ckan/ckan/issues/9313) that CKAN 2.11.x is compatible.